### PR TITLE
SQA fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,7 @@ conf_vars.mk
 # GPerf performance
 *.prof
 *.heap
+
+# Generated resource files
+unit/malamute-unit.yaml
+malamute.yaml

--- a/doc/content/sqa/malamute_cci.md
+++ b/doc/content/sqa/malamute_cci.md
@@ -10,4 +10,4 @@ using the [{{app}} Discussion forum](https://github.com/idaholab/{{category}}/di
 to include the release information with the inquiry.
 
 !template item key=contributing
-With the exception of the location of the [code repository for {{app}}](https://github.com/idaholab/{{category}}), the same processes outlined in the instructions for contributing to the MOOSE framework [framework/contributing.md] apply for contributing to {{app}}.
+With the exception of the location of the [code repository for {{app}}](https://github.com/idaholab/{{category}}), the same processes outlined in the [instructions for contributing to the MOOSE framework](framework/contributing.md) apply for contributing to {{app}}.

--- a/doc/content/sqa/malamute_sdd.md
+++ b/doc/content/sqa/malamute_sdd.md
@@ -18,7 +18,9 @@ with no additional dependencies.
 !template-end!
 
 !template! item key=design-stakeholders
-!include framework_sdd.md start=design-stakeholders-begin end=design-stakeholders-finish
+Stakeholders for {{app}} include several of the funding sources including [!ac](DOE) and [!ac](INL).
+However, Since {{app}} is an open-source project, several universities, companies, and foreign governments
+have an interest in the development and maintenance of the {{app}} project.
 !template-end!
 
 !template! item key=system-design


### PR DESCRIPTION
This PR also instructs git to ignore `malamute.yaml` and `unit/malamute-unit.yaml` which are now generated during build of the main and unit executables, respectively. 

Refs #73