### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/materials/ADGaussianHeatSourceBase.C
+++ b/src/materials/ADGaussianHeatSourceBase.C
@@ -20,6 +20,7 @@ ADGaussianHeatSourceBase::validParams()
                         "option to use user input effective radii or from experimentally fitted "
                         "formulations. Default is to use user input data.");
   params.addParam<std::vector<Real>>("r",
+                                     {},
                                      "effective radii (mm) along three directions. If only one "
                                      "parameter is provided, then we assume "
                                      "the effective radius to be equal along three directions.");


### PR DESCRIPTION
## Bug Description
<!--A clear and concise description of the error, failure, fault, incorrect or unexpected result, or unintended behavior (Note: A missing feature is not a bug.).-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This new fix in MOOSE cause several tests failed in Malamute which don't provide default value for vector parameter. 

## Impact
<!--Does this prevent you from getting your work done, or is it more of an annoyance?-->
This patch is made to fix the failed Malamute tests due to the new changes in MOOSE