### PR TITLE
Fix RosenthalTemperatureSource registration

### DIFF
--- a/src/materials/RosenthalTemperatureSource.C
+++ b/src/materials/RosenthalTemperatureSource.C
@@ -9,8 +9,8 @@
 
 #include "RosenthalTemperatureSource.h"
 
-registerMooseObject("HeatConductionApp", RosenthalTemperatureSource);
-registerMooseObject("HeatConductionApp", ADRosenthalTemperatureSource);
+registerMooseObject("MalamuteApp", RosenthalTemperatureSource);
+registerMooseObject("MalamuteApp", ADRosenthalTemperatureSource);
 
 template <bool is_ad>
 InputParameters


### PR DESCRIPTION
Refs failure on idaholab/moose#25585