### PR TITLE
Decrease coverage requirement due to compiler change

### DIFF
--- a/.coverage
+++ b/.coverage
@@ -6,5 +6,5 @@
 # - warn_new: Warns below this percentage of coverage for new lines added
 
 [default]
-require_total = 69
+require_total = 68
 warn_new = 90


### PR DESCRIPTION
Compiler was changed from GCC 8 -> 12 in idaholab/moose#26102, which caused small differences in what was considered a covered and uncovered line.

Devel is currently failing on the moose submodule update due to this: https://civet.inl.gov/job/1915607/