### PR TITLE
Fix failing deprecated tests

### DIFF
--- a/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
@@ -303,7 +303,7 @@ dt = 200
   [exodus]
     type = Exodus
     file_base = 'output/Exodus/Mechanical'
-    interval = 1
+    time_step_interval = 1
   []
 []
 

--- a/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
@@ -310,7 +310,7 @@ dt = 200
   [exodus]
     type = Exodus
     file_base = 'output/Exodus/Thermal'
-    interval = 1
+    time_step_interval = 1
   []
 []
 

--- a/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
@@ -303,7 +303,7 @@ dt = 20
   [exodus]
     type = Exodus
     file_base = 'output/Exodus/Mechanical'
-    interval = 1
+    time_step_interval = 1
   []
 []
 

--- a/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
@@ -315,7 +315,7 @@ dt = 20
   [exodus]
     type = Exodus
     file_base = 'output/Exodus/Thermal'
-    interval = 1
+    time_step_interval = 1
   []
 []
 

--- a/examples/sps/multiapp/complete_geometry/electrothermal/engineering_scale_electrothermal.i
+++ b/examples/sps/multiapp/complete_geometry/electrothermal/engineering_scale_electrothermal.i
@@ -946,7 +946,7 @@ initial_temperature=293 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/examples/sps/multiapp/complete_geometry/electrothermal/engineering_scale_electrothermal_goofycontact.i
+++ b/examples/sps/multiapp/complete_geometry/electrothermal/engineering_scale_electrothermal_goofycontact.i
@@ -959,7 +959,7 @@ initial_temperature=293 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/examples/sps/multiapp/diemodel/electrothermal/electrothermal_plunger_powder.i
+++ b/examples/sps/multiapp/diemodel/electrothermal/electrothermal_plunger_powder.i
@@ -544,7 +544,7 @@ initial_temperature=300 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   [ckpt]
     type =Checkpoint
-    interval = 1
+    time_step_interval = 1
     num_files = 2
   []
 []

--- a/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_bothends_pressurebc.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_bothends_pressurebc.i
@@ -717,7 +717,7 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   [ckpt]
     type = Checkpoint
-    interval = 1
+    time_step_interval = 1
     num_files = 2
   []
 []

--- a/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_creep.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_creep.i
@@ -734,7 +734,7 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   [ckpt]
     type = Checkpoint
-    interval = 1
+    time_step_interval = 1
     num_files = 2
   []
 []

--- a/examples/sps/multiapp/diemodel/electrothermomechs/mechanical_plunger_powder_plastic.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/mechanical_plunger_powder_plastic.i
@@ -360,7 +360,7 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/engineering_scale_electrothermal_oneway_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/engineering_scale_electrothermal_oneway_controls.i
@@ -975,7 +975,7 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/engineering_scale_electrothermal_twoway_prototype.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/engineering_scale_electrothermal_twoway_prototype.i
@@ -1019,7 +1019,7 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/engineering_scale_electrothermal_twoway_lots_prototype.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/engineering_scale_electrothermal_twoway_lots_prototype.i
@@ -1022,7 +1022,7 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
   perf_graph = true
   # [ckpt]
   #   type =Checkpoint
-  #   interval = 1
+  #   time_step_interval = 1
   #   num_files = 2
   # []
 []

--- a/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
@@ -51,9 +51,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       [./all]
         strain = SMALL
         decomposition_method = EigenSolution

--- a/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
@@ -51,9 +51,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       [./all]
         strain = SMALL
         decomposition_method = EigenSolution

--- a/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
@@ -50,9 +50,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       [./all]
         strain = SMALL
         decomposition_method = EigenSolution

--- a/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
@@ -51,9 +51,9 @@
   [../]
 []
 
-[Modules]
-  [./TensorMechanics]
-    [./Master]
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
       [./all]
         strain = SMALL
         decomposition_method = EigenSolution


### PR DESCRIPTION
## Bug Description
MALAMUTE currently has several failing tests due to code deprecations from MOOSE: https://civet.inl.gov/job/2187228/

## Steps to Reproduce
Run MALAMUTE tests with `./run_tests -j4 --error-deprecated`

## Impact
An annoyance currently, but eventually a code-breaking issue.
