### PR TITLE
hit formatting of "electrothermal with phase field" input files

### DIFF
--- a/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/engineering_scale_electrothermal_oneway_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/engineering_scale_electrothermal_oneway_controls.i
@@ -88,7 +88,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     initial_condition = 2.0e-10 #in units eV/((nV)^2-s-nm)
     block = 'powder_compact'
   []
-  [microapp_potential] #converted to microapp electronVolts units
+  [microapp_potential]
+    #converted to microapp electronVolts units
     block = 'powder_compact'
   []
   [E_x]
@@ -616,10 +617,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ##Thermal Contact between gapped graphite die components
-[ThermalContact]
   [upper_plunger_spacer_gap_thermal]
     type = GapHeatTransfer
     primary = spacer_facing_upper_plunger
@@ -698,10 +697,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ## Thermal Contact between touching components of powder and die
-[ThermalContact]
   [upper_plunger_powder_thermal]
     type = GapHeatTransfer
     primary = bottom_upper_plunger

--- a/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/micro_yttria_thermoelectric_oneway_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/micro_yttria_thermoelectric_oneway_controls.i
@@ -69,11 +69,13 @@ initial_field = 10 #from the engineering scale, starting value 10 V/m
   []
   [T]
   []
-  [Q_joule] #Problem units of eV/nm^3/s
+  [Q_joule]
+    #Problem units of eV/nm^3/s
     order = CONSTANT
     family = MONOMIAL
   []
-  [Q_joule_SI] #SI units of J/m^3/s
+  [Q_joule_SI]
+    #SI units of J/m^3/s
     order = CONSTANT
     family = MONOMIAL
   []

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/engineering_scale_electrothermal_twoway_prototype.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/engineering_scale_electrothermal_twoway_prototype.i
@@ -88,7 +88,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     initial_condition = 2.0e-10 #in units eV/((nV)^2-s-nm)
     block = 'powder_compact'
   []
-  [microapp_potential] #converted to microapp electronVolts units
+  [microapp_potential]
+    #converted to microapp electronVolts units
     block = 'powder_compact'
   []
   [E_x]
@@ -152,7 +153,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
   #   family = MONOMIAL
   #   order = FIRST
   # []
-  [Q_from_sub] #this will be in eV/m/s, will need unit conversion to J/m^3/s based on phase-field domain size
+  [Q_from_sub]
+    #this will be in eV/m/s, will need unit conversion to J/m^3/s based on phase-field domain size
     order = FIRST
     family = LAGRANGE
   []
@@ -625,10 +627,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ##Thermal Contact between gapped graphite die components
-[ThermalContact]
   [upper_plunger_spacer_gap_thermal]
     type = GapHeatTransfer
     primary = spacer_facing_upper_plunger
@@ -707,10 +707,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ## Thermal Contact between touching components of powder and die
-[ThermalContact]
   [upper_plunger_powder_thermal]
     type = GapHeatTransfer
     primary = bottom_upper_plunger

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/micro_yttria_thermoelectric_twoway.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/micro_yttria_thermoelectric_twoway.i
@@ -44,16 +44,20 @@ initial_voltage = 0.0001
   []
   [dV]
   []
-  [Tx_AEH] #Temperature used for the x-component of the AEH solve
+  [Tx_AEH]
+    #Temperature used for the x-component of the AEH solve
     initial_condition = ${initial_temperature}
   []
-  [Ty_AEH] #Temperature used for the y-component of the AEH solve
+  [Ty_AEH]
+    #Temperature used for the y-component of the AEH solve
     initial_condition = ${initial_temperature}
   []
-  [Vx_AEH] #Voltage potential used for the x-component of the AEH solve
+  [Vx_AEH]
+    #Voltage potential used for the x-component of the AEH solve
     initial_condition = ${initial_voltage}
   []
-  [Vy_AEH] #Voltage potential used for the y-component of the AEH solve
+  [Vy_AEH]
+    #Voltage potential used for the y-component of the AEH solve
     initial_condition = ${initial_voltage}
   []
 []
@@ -91,7 +95,8 @@ initial_voltage = 0.0001
   []
   [T]
   []
-  [Q_joule] #Problem units of eV/nm^3/s
+  [Q_joule]
+    #Problem units of eV/nm^3/s
     order = CONSTANT
     family = MONOMIAL
   []
@@ -176,25 +181,29 @@ initial_voltage = 0.0001
       variable = 'Tx_AEH Ty_AEH Vx_AEH Vy_AEH'
     []
   []
-  [fix_AEH_Tx] #Fix Tx_AEH at a single point
+  [fix_AEH_Tx]
+    #Fix Tx_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Tx_AEH
     postprocessor = T_postproc
     boundary = 1000
   []
-  [fix_AEH_Ty] #Fix Ty_AEH at a single point
+  [fix_AEH_Ty]
+    #Fix Ty_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Ty_AEH
     postprocessor = T_postproc
     boundary = 1000
   []
-  [fix_AEH_Vx] #Fix Tx_AEH at a single point
+  [fix_AEH_Vx]
+    #Fix Tx_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Vx_AEH
     postprocessor = V_postproc
     boundary = 1000
   []
-  [fix_AEH_Vy] #Fix Ty_AEH at a single point
+  [fix_AEH_Vy]
+    #Fix Ty_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Vy_AEH
     postprocessor = V_postproc
@@ -528,7 +537,8 @@ initial_voltage = 0.0001
     diffusivity = electrical_conductivity
     args = 'phi'
   []
-  [heat_x] #Following kernels are for AEH approach to calculate thermal cond.
+  [heat_x]
+    #Following kernels are for AEH approach to calculate thermal cond.
     type = HeatConduction
     variable = Tx_AEH
   []
@@ -546,7 +556,8 @@ initial_voltage = 0.0001
     variable = Ty_AEH
     component = 1
   []
-  [voltage_x] #The following four kernels are for AEH approach to calculate electrical cond.
+  [voltage_x]
+    #The following four kernels are for AEH approach to calculate electrical cond.
     type = HeatConduction
     variable = Vx_AEH
     diffusion_coefficient = electrical_conductivity
@@ -654,14 +665,16 @@ initial_voltage = 0.0001
     type = Receiver
     default = ${initial_voltage}
   []
-  [k_x_AEH] #Effective thermal conductivity in x-direction from AEH
+  [k_x_AEH]
+    #Effective thermal conductivity in x-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Tx_AEH Ty_AEH'
     row = 0
     col = 0
     execute_on = TIMESTEP_END
   []
-  [k_y_AEH] #Effective thermal conductivity in y-direction from AEH
+  [k_y_AEH]
+    #Effective thermal conductivity in y-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Tx_AEH Ty_AEH'
     row = 1
@@ -673,7 +686,8 @@ initial_voltage = 0.0001
     pp_coefs = '0.5 0.5'
     pp_names = 'k_x_AEH k_y_AEH'
   []
-  [sigma_x_AEH] #Effective electrical conductivity in x-direction from AEH
+  [sigma_x_AEH]
+    #Effective electrical conductivity in x-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Vx_AEH Vy_AEH'
     row = 0
@@ -681,7 +695,8 @@ initial_voltage = 0.0001
     execute_on = TIMESTEP_END
     diffusion_coefficient = electrical_conductivity
   []
-  [sigma_y_AEH] #Effective electrical conductivity in y-direction from AEH
+  [sigma_y_AEH]
+    #Effective electrical conductivity in y-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Vx_AEH Vy_AEH'
     row = 1

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/engineering_scale_electrothermal_twoway_lots_prototype.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/engineering_scale_electrothermal_twoway_lots_prototype.i
@@ -93,7 +93,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     initial_condition = 2.0e-10 #in units eV/((nV)^2-s-nm)
     block = 'powder_compact'
   []
-  [microapp_potential] #converted to microapp electronVolts units
+  [microapp_potential]
+    #converted to microapp electronVolts units
     block = 'powder_compact'
   []
   [E_x]
@@ -112,7 +113,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     block = 'powder_compact'
   []
 
-  [Q_from_sub] #this will be in eV/m/s, will need unit conversion to J/m^3/s based on phase-field domain size
+  [Q_from_sub]
+    #this will be in eV/m/s, will need unit conversion to J/m^3/s based on phase-field domain size
     order = FIRST
     family = LAGRANGE
   []
@@ -629,10 +631,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ##Thermal Contact between gapped graphite die components
-[ThermalContact]
   [upper_plunger_spacer_gap_thermal]
     type = GapHeatTransfer
     primary = spacer_facing_upper_plunger
@@ -711,10 +711,8 @@ initial_temperature = 873 #roughly 600C where the pyrometer kicks in
     gap_conductivity_function_variable = temperature
     normal_smoothing_distance = 0.1
   []
-[]
 
 ## Thermal Contact between touching components of powder and die
-[ThermalContact]
   [upper_plunger_powder_thermal]
     type = GapHeatTransfer
     primary = bottom_upper_plunger

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/micro_yttria_thermoelectric_twoway_lots_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/micro_yttria_thermoelectric_twoway_lots_controls.i
@@ -44,16 +44,20 @@ initial_voltage = 0.0001
   []
   [dV]
   []
-  [Tx_AEH] #Temperature used for the x-component of the AEH solve
+  [Tx_AEH]
+    #Temperature used for the x-component of the AEH solve
     initial_condition = 300
   []
-  [Ty_AEH] #Temperature used for the y-component of the AEH solve
+  [Ty_AEH]
+    #Temperature used for the y-component of the AEH solve
     initial_condition = 300
   []
-  [Vx_AEH] #Voltage potential used for the x-component of the AEH solve
+  [Vx_AEH]
+    #Voltage potential used for the x-component of the AEH solve
     initial_condition = ${initial_voltage}
   []
-  [Vy_AEH] #Voltage potential used for the y-component of the AEH solve
+  [Vy_AEH]
+    #Voltage potential used for the y-component of the AEH solve
     initial_condition = ${initial_voltage}
   []
 []
@@ -91,7 +95,8 @@ initial_voltage = 0.0001
   []
   [T]
   []
-  [Q_joule] #Problem units of eV/nm^3/s
+  [Q_joule]
+    #Problem units of eV/nm^3/s
     order = CONSTANT
     family = MONOMIAL
   []
@@ -157,25 +162,29 @@ initial_voltage = 0.0001
       variable = 'Tx_AEH Ty_AEH Vx_AEH Vy_AEH'
     []
   []
-  [fix_AEH_Tx] #Fix Tx_AEH at a single point
+  [fix_AEH_Tx]
+    #Fix Tx_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Tx_AEH
     postprocessor = T_postproc
     boundary = 1000
   []
-  [fix_AEH_Ty] #Fix Ty_AEH at a single point
+  [fix_AEH_Ty]
+    #Fix Ty_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Ty_AEH
     postprocessor = T_postproc
     boundary = 1000
   []
-  [fix_AEH_Vx] #Fix Tx_AEH at a single point
+  [fix_AEH_Vx]
+    #Fix Tx_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Vx_AEH
     postprocessor = V_postproc
     boundary = 1000
   []
-  [fix_AEH_Vy] #Fix Ty_AEH at a single point
+  [fix_AEH_Vy]
+    #Fix Ty_AEH at a single point
     type = PostprocessorDirichletBC
     variable = Vy_AEH
     postprocessor = V_postproc
@@ -525,7 +534,8 @@ initial_voltage = 0.0001
     diffusivity = electrical_conductivity
     args = 'phi'
   []
-  [heat_x] #Following kernels are for AEH approach to calculate thermal cond.
+  [heat_x]
+    #Following kernels are for AEH approach to calculate thermal cond.
     type = HeatConduction
     variable = Tx_AEH
   []
@@ -543,7 +553,8 @@ initial_voltage = 0.0001
     variable = Ty_AEH
     component = 1
   []
-  [voltage_x] #The following four kernels are for AEH approach to calculate electrical cond.
+  [voltage_x]
+    #The following four kernels are for AEH approach to calculate electrical cond.
     type = HeatConduction
     variable = Vx_AEH
     diffusion_coefficient = electrical_conductivity
@@ -658,14 +669,16 @@ initial_voltage = 0.0001
     type = Receiver
     default = ${initial_voltage}
   []
-  [k_x_AEH] #Effective thermal conductivity in x-direction from AEH
+  [k_x_AEH]
+    #Effective thermal conductivity in x-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Tx_AEH Ty_AEH'
     row = 0
     col = 0
     execute_on = TIMESTEP_END
   []
-  [k_y_AEH] #Effective thermal conductivity in y-direction from AEH
+  [k_y_AEH]
+    #Effective thermal conductivity in y-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Tx_AEH Ty_AEH'
     row = 1
@@ -677,7 +690,8 @@ initial_voltage = 0.0001
     pp_coefs = '0.5 0.5'
     pp_names = 'k_x_AEH k_y_AEH'
   []
-  [sigma_x_AEH] #Effective electrical conductivity in x-direction from AEH
+  [sigma_x_AEH]
+    #Effective electrical conductivity in x-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Vx_AEH Vy_AEH'
     row = 0
@@ -685,7 +699,8 @@ initial_voltage = 0.0001
     execute_on = TIMESTEP_END
     diffusion_coefficient = electrical_conductivity
   []
-  [sigma_y_AEH] #Effective electrical conductivity in y-direction from AEH
+  [sigma_y_AEH]
+    #Effective electrical conductivity in y-direction from AEH
     type = HomogenizedThermalConductivity
     chi = 'Vx_AEH Vy_AEH'
     row = 1


### PR DESCRIPTION
We will rely on the syntax checking in CIVET to test these files for continued functionality, particularly the two input files located in this file path: ~/projects/malamute/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype. 

I was not able to compare the simulation outputs for these two input files located in "twoway_lots_of_particles_prototype".

For the remaining four input files, I performed a comparison between two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input file.

Refs #128