### PR TITLE
hit formatting of directed energy input files

### DIFF
--- a/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
@@ -127,21 +127,25 @@ dt = 200
   []
 []
 
-[Physics/SolidMechanics/QuasiStatic]
-  strain = FINITE
-  incremental = true
-  generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
-                    'strain_zz strain_xy strain_xz strain_yz'
-  use_automatic_differentiation = true
-  [product]
-    block = '2'
-    eigenstrain_names = 'thermal_eigenstrain_product'
-    use_automatic_differentiation = true
-  []
-  [substrate]
-    block = '3'
-    eigenstrain_names = 'thermal_eigenstrain_substrate'
-    use_automatic_differentiation = true
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
+      strain = FINITE
+      incremental = true
+      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
+                        'strain_zz strain_xy strain_xz strain_yz'
+      use_automatic_differentiation = true
+      [product]
+        block = '2'
+        eigenstrain_names = 'thermal_eigenstrain_product'
+        use_automatic_differentiation = true
+      []
+      [substrate]
+        block = '3'
+        eigenstrain_names = 'thermal_eigenstrain_substrate'
+        use_automatic_differentiation = true
+      []
+    []
   []
 []
 
@@ -255,15 +259,19 @@ dt = 200
   marker = marker
   initial_marker = marker
   max_h_level = 3
-  [Indicators/indicator]
-    type = GradientJumpIndicator
-    variable = temp_aux
+  [Indicators]
+    [indicator]
+      type = GradientJumpIndicator
+      variable = temp_aux
+    []
   []
-  [Markers/marker]
-    type = ErrorFractionMarker
-    indicator = indicator
-    coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
-    refine = 0.5
+  [Markers]
+    [marker]
+      type = ErrorFractionMarker
+      indicator = indicator
+      coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
+      refine = 0.5
+    []
   []
 []
 

--- a/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
@@ -261,15 +261,19 @@ dt = 200
   marker = marker
   initial_marker = marker
   max_h_level = 2
-  [Indicators/indicator]
-    type = GradientJumpIndicator
-    variable = temp
+  [Indicators]
+    [indicator]
+      type = GradientJumpIndicator
+      variable = temp
+    []
   []
-  [Markers/marker]
-    type = ErrorFractionMarker
-    indicator = indicator
-    coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
-    refine = 0.5
+  [Markers]
+    [marker]
+      type = ErrorFractionMarker
+      indicator = indicator
+      coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
+      refine = 0.5
+    []
   []
 []
 

--- a/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
@@ -127,21 +127,25 @@ dt = 20
   []
 []
 
-[Physics/SolidMechanics/QuasiStatic]
-  strain = FINITE
-  incremental = true
-  generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
-                    'strain_zz strain_xy strain_xz strain_yz'
-  use_automatic_differentiation = true
-  [product]
-    block = '2'
-    eigenstrain_names = 'thermal_eigenstrain_product'
-    use_automatic_differentiation = true
-  []
-  [substrate]
-    block = '3'
-    eigenstrain_names = 'thermal_eigenstrain_substrate'
-    use_automatic_differentiation = true
+[Physics]
+  [SolidMechanics]
+    [QuasiStatic]
+      strain = FINITE
+      incremental = true
+      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
+                        'strain_zz strain_xy strain_xz strain_yz'
+      use_automatic_differentiation = true
+      [product]
+        block = '2'
+        eigenstrain_names = 'thermal_eigenstrain_product'
+        use_automatic_differentiation = true
+      []
+      [substrate]
+        block = '3'
+        eigenstrain_names = 'thermal_eigenstrain_substrate'
+        use_automatic_differentiation = true
+      []
+    []
   []
 []
 
@@ -255,15 +259,19 @@ dt = 20
   marker = marker
   initial_marker = marker
   max_h_level = 3
-  [Indicators/indicator]
-    type = GradientJumpIndicator
-    variable = temp_aux
+  [Indicators]
+    [indicator]
+      type = GradientJumpIndicator
+      variable = temp_aux
+    []
   []
-  [Markers/marker]
-    type = ErrorFractionMarker
-    indicator = indicator
-    coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
-    refine = 0.5
+  [Markers]
+    [marker]
+      type = ErrorFractionMarker
+      indicator = indicator
+      coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
+      refine = 0.5
+    []
   []
 []
 

--- a/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
@@ -266,15 +266,19 @@ dt = 20
   marker = marker
   initial_marker = marker
   max_h_level = 2
-  [Indicators/indicator]
-    type = GradientJumpIndicator
-    variable = temp
+  [Indicators]
+    [indicator]
+      type = GradientJumpIndicator
+      variable = temp
+    []
   []
-  [Markers/marker]
-    type = ErrorFractionMarker
-    indicator = indicator
-    coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
-    refine = 0.5
+  [Markers]
+    [marker]
+      type = ErrorFractionMarker
+      indicator = indicator
+      coarsen = 0 # coarsening is pending MOOSE PR #23078 being merged
+      refine = 0.5
+    []
   []
 []
 


### PR DESCRIPTION
We will rely on the syntax checking in CIVET to test these files for continued functionality, particularly the two input files located in these two separate file paths: 
~/projects/malamute/examples/directed_energy_deposition/cylinder/
~/projects/malamute/examples//directed_energy_deposition/hollow_cylinder/

Both input files in question were titled "master_app_mechanical.i"

I was not able to compare the simulation outputs for these two input files located in "directed_energy_deposition". 

For the remaining two input files, I performed a comparison between two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input file.