### PR TITLE
hit formatting of "melt pool 3d" input files

### DIFF
--- a/examples/melt_pool_3d/melt_pool.i
+++ b/examples/melt_pool_3d/melt_pool.i
@@ -70,11 +70,13 @@
   []
 []
 
-[Functions/ls_exact]
-   type = LevelSetOlssonPlane
-   epsilon = 0.00008
-   point = '0.005 0.005 0.005'
-   normal = '0 0 1'
+[Functions]
+  [ls_exact]
+    type = LevelSetOlssonPlane
+    epsilon = 0.00008
+    point = '0.005 0.005 0.005'
+    normal = '0 0 1'
+  []
 []
 
 [BCs]

--- a/examples/melt_pool_3d/reinit.i
+++ b/examples/melt_pool_3d/reinit.i
@@ -1,16 +1,18 @@
-[Mesh/gen]
-  type = GeneratedMeshGenerator
-  dim = 3
-  xmin = 0
-  xmax = 0.01
-  ymin = 0
-  ymax = 0.01
-  zmin = 0
-  zmax = 0.01
-  nx = 50
-  ny = 50
-  nz = 50
-  elem_type = HEX8
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 3
+    xmin = 0
+    xmax = 0.01
+    ymin = 0
+    ymax = 0.01
+    zmin = 0
+    zmax = 0.01
+    nx = 50
+    ny = 50
+    nz = 50
+    elem_type = HEX8
+  []
 []
 
 [Adaptivity]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input file.
Refs #128