### PR TITLE
hit formatting of bcs input files

### DIFF
--- a/test/tests/bcs/radiation_heat_loss/multiple_phases_simple_radiation.i
+++ b/test/tests/bcs/radiation_heat_loss/multiple_phases_simple_radiation.i
@@ -25,41 +25,41 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 400.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./heat]
+  [heat]
     type = HeatConduction
     variable = temperature
-  [../]
+  []
 []
 
 [BCs]
-  [./heatloss]
+  [heatloss]
     type = ADCoupledSimpleRadiativeHeatFluxBC
     boundary = right
     variable = temperature
     T_infinity = '293 293'
     emissivity = '0.95 0.07'
     alpha = '0.4 0.6'
-  [../]
-  [./insulation]
+  []
+  [insulation]
     type = DirichletBC
     boundary = 'left'
     variable = temperature
     value = 400
-  [../]
+  []
 []
 
 [Materials]
-  [./density]
+  [density]
     type = GenericConstantMaterial
     prop_names = 'thermal_conductivity'
     prop_values = '1e3'
-  [../]
+  []
 []
 
 [Executioner]
@@ -68,17 +68,17 @@
 []
 
 [Postprocessors]
-  [./right_temperature]
+  [right_temperature]
     type = SideAverageValue
     variable = temperature
     boundary = right
-  [../]
-  [./right_heatflux]
+  []
+  [right_heatflux]
     type = SideDiffusiveFluxIntegral
     variable = temperature
     boundary = right
     diffusivity = thermal_conductivity
-  [../]
+  []
 []
 
 [Outputs]

--- a/test/tests/bcs/radiation_heat_loss/simple_radiation.i
+++ b/test/tests/bcs/radiation_heat_loss/simple_radiation.i
@@ -24,40 +24,40 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 302.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./heat]
+  [heat]
     type = HeatConduction
     variable = temperature
-  [../]
+  []
 []
 
 [BCs]
-  [./heatloss]
+  [heatloss]
     type = ADCoupledSimpleRadiativeHeatFluxBC
     boundary = right
     variable = temperature
     T_infinity = 293
     emissivity = 0.95
-  [../]
-  [./insulation]
+  []
+  [insulation]
     type = DirichletBC
     boundary = 'left'
     variable = temperature
     value = 302
-  [../]
+  []
 []
 
 [Materials]
-  [./density]
+  [density]
     type = GenericConstantMaterial
     prop_names = 'thermal_conductivity'
     prop_values = '9.5e3'
-  [../]
+  []
 []
 
 [Executioner]
@@ -67,17 +67,17 @@
 []
 
 [Postprocessors]
-  [./right_temperature]
+  [right_temperature]
     type = SideAverageValue
     variable = temperature
     boundary = right
-  [../]
-  [./right_heatflux]
+  []
+  [right_heatflux]
     type = SideDiffusiveFluxIntegral
     variable = temperature
     boundary = right
     diffusivity = thermal_conductivity
-  [../]
+  []
 []
 
 [Outputs]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.
Refs #128 