### PR TITLE
hit formatting of curvature regulation input file

### DIFF
--- a/test/tests/curvature_regularization/curvature_regularization.i
+++ b/test/tests/curvature_regularization/curvature_regularization.i
@@ -20,14 +20,18 @@
   []
 []
 
-[AuxVariables/ls]
+[AuxVariables]
+  [ls]
+  []
 []
 
-[AuxKernels/ls_aux]
-  type = FunctionAux
-  variable = ls
-  function = ls_func
-  execute_on = initial
+[AuxKernels]
+  [ls_aux]
+    type = FunctionAux
+    variable = ls
+    function = ls_func
+    execute_on = initial
+  []
 []
 
 [Variables]
@@ -39,23 +43,25 @@
 []
 
 [Kernels]
- [curvature]
-   type = LevelSetCurvatureRegularization
-   level_set_regularized_gradient = grad_ls
-   variable = curvature
-   varepsilon = 0.04
- []
- [grad_ls]
-   type = VariableGradientRegularization
-   regularized_var = ls
-   variable = grad_ls
- []
+  [curvature]
+    type = LevelSetCurvatureRegularization
+    level_set_regularized_gradient = grad_ls
+    variable = curvature
+    varepsilon = 0.04
+  []
+  [grad_ls]
+    type = VariableGradientRegularization
+    regularized_var = ls
+    variable = grad_ls
+  []
 []
 
-[Functions/ls_func]
-  type = LevelSetOlssonBubble
-  center = '0.5 0.5 0'
-  radius = 0.15
+[Functions]
+  [ls_func]
+    type = LevelSetOlssonBubble
+    center = '0.5 0.5 0'
+    radius = 0.15
+  []
 []
 
 [Preconditioning]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.

Refs #128 