### PR TITLE
hit formatting of gradient regularization input file

### DIFF
--- a/test/tests/gradient_regularization/gradient_regularization.i
+++ b/test/tests/gradient_regularization/gradient_regularization.i
@@ -20,30 +20,40 @@
   []
 []
 
-[AuxVariables/ls]
+[AuxVariables]
+  [ls]
+  []
 []
 
-[AuxKernels/ls_aux]
-  type = FunctionAux
-  variable = ls
-  function = ls_func
-  execute_on = initial
+[AuxKernels]
+  [ls_aux]
+    type = FunctionAux
+    variable = ls
+    function = ls_func
+    execute_on = initial
+  []
 []
 
-[Variables/grad_ls]
-  family = LAGRANGE_VEC
+[Variables]
+  [grad_ls]
+    family = LAGRANGE_VEC
+  []
 []
 
-[Kernels/grad_ls]
-  type = VariableGradientRegularization
-  regularized_var = ls
-  variable = grad_ls
+[Kernels]
+  [grad_ls]
+    type = VariableGradientRegularization
+    regularized_var = ls
+    variable = grad_ls
+  []
 []
 
-[Functions/ls_func]
-  type = LevelSetOlssonBubble
-  center = '0.5 0.5 0'
-  radius = 0.15
+[Functions]
+  [ls_func]
+    type = LevelSetOlssonBubble
+    center = '0.5 0.5 0'
+    radius = 0.15
+  []
 []
 
 [Preconditioning]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input file.
Refs #128 