### PR TITLE
hit formatting of interface kernels input files

### DIFF
--- a/test/tests/interfacekernels/thermal_conductance/thermal_interface.i
+++ b/test/tests/interfacekernels/thermal_conductance/thermal_interface.i
@@ -5,112 +5,112 @@
 []
 
 [Variables]
-  [./temperature_graphite]
+  [temperature_graphite]
     initial_condition = 300.0
     block = graphite
-  [../]
-  [./temperature_stainless_steel]
+  []
+  [temperature_stainless_steel]
     initial_condition = 300.0
     block = stainless_steel
-  [../]
-  [./potential_graphite]
+  []
+  [potential_graphite]
     block = graphite
-  [../]
-  [./potential_stainless_steel]
+  []
+  [potential_stainless_steel]
     block = stainless_steel
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./T_infinity]
+  [T_infinity]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff_graphite]
+  [HeatDiff_graphite]
     type = ADHeatConduction
     variable = temperature_graphite
     block = graphite
-  [../]
-  [./HeatTdot_graphite]
+  []
+  [HeatTdot_graphite]
     type = ADHeatConductionTimeDerivative
     variable = temperature_graphite
     block = graphite
-  [../]
-  [./HeatSource_graphite]
+  []
+  [HeatSource_graphite]
     type = ADJouleHeatingSource
     variable = temperature_graphite
     elec = potential_graphite
     electrical_conductivity = electrical_conductivity
     block = graphite
-  [../]
+  []
 
-  [./HeatDiff_stainless_steel]
+  [HeatDiff_stainless_steel]
     type = ADHeatConduction
     variable = temperature_stainless_steel
     block = stainless_steel
-  [../]
-  [./HeatTdot_stainless_steel]
+  []
+  [HeatTdot_stainless_steel]
     type = ADHeatConductionTimeDerivative
     variable = temperature_stainless_steel
     block = stainless_steel
-  [../]
-  [./HeatSource_stainless_steel]
+  []
+  [HeatSource_stainless_steel]
     type = ADJouleHeatingSource
     variable = temperature_stainless_steel
     elec = potential_stainless_steel
     electrical_conductivity = electrical_conductivity
     block = stainless_steel
-  [../]
+  []
 
-  [./electric_graphite]
+  [electric_graphite]
     type = ADMatDiffusion
     variable = potential_graphite
     diffusivity = electrical_conductivity
     block = graphite
-  [../]
-  [./electric_stainless_steel]
+  []
+  [electric_stainless_steel]
     type = ADMatDiffusion
     variable = potential_stainless_steel
     diffusivity = electrical_conductivity
     block = stainless_steel
-  [../]
+  []
 []
 
 [BCs]
-  [./external_surface_stainless]
+  [external_surface_stainless]
     type = ADCoupledSimpleRadiativeHeatFluxBC
     boundary = right_stainless_steel
     variable = temperature_stainless_steel
     T_infinity = T_infinity
     emissivity = 0.85
-  [../]
-  [./external_surface_graphite]
+  []
+  [external_surface_graphite]
     type = ADCoupledSimpleRadiativeHeatFluxBC
     boundary = right_graphite
     variable = temperature_graphite
     T_infinity = T_infinity
     emissivity = 0.85
-  [../]
-  [./elec_top]
+  []
+  [elec_top]
     type = ADDirichletBC
     variable = potential_stainless_steel
     boundary = top_die
-    value = 0.68  # Better reflects Cincotti et al (DOI: 10.1002/aic.11102) Figure 19
-  [../]
-  [./elec_bottom]
+    value = 0.68 # Better reflects Cincotti et al (DOI: 10.1002/aic.11102) Figure 19
+  []
+  [elec_bottom]
     type = ADDirichletBC
     variable = potential_stainless_steel
     boundary = bottom_die
     value = 0
-  [../]
+  []
 []
 
 [InterfaceKernels]
   active = 'thermal_contact_conductance electric_contact_conductance'
 
-  [./thermal_contact_conductance]
+  [thermal_contact_conductance]
     type = ThermalContactCondition
     variable = temperature_stainless_steel
     neighbor_var = temperature_graphite
@@ -123,8 +123,8 @@
     user_electrical_contact_conductance = 2.5e5 # as described in Cincotti et al (DOI: 10.1002/aic.11102)
     user_thermal_contact_conductance = 7 # also from Cincotti et al
     boundary = ssg_interface
-  [../]
-  [./electric_contact_conductance]
+  []
+  [electric_contact_conductance]
     type = ElectrostaticContactCondition
     variable = potential_stainless_steel
     neighbor_var = potential_graphite
@@ -132,9 +132,9 @@
     secondary_conductivity = electrical_conductivity
     boundary = ssg_interface
     user_electrical_contact_conductance = 2.5e5 # as described in Cincotti et al (DOI: 10.1002/aic.11102)
-  [../]
+  []
 
-  [./thermal_contact_conductance_calculated]
+  [thermal_contact_conductance_calculated]
     type = ThermalContactCondition
     variable = temperature_stainless_steel
     neighbor_var = temperature_graphite
@@ -147,67 +147,67 @@
     mean_hardness = graphite_stainless_mean_hardness
     mechanical_pressure = 8.52842e10 # resulting in electrical contact conductance = ~1.4715e5, thermal contact conductance = ~3.44689e7
     boundary = ssg_interface
-  [../]
+  []
 []
 
 [Materials]
   active = 'heat_conductor_graphite rho_graphite sigma_graphite heat_conductor_stainless_steel rho_stainless_steel sigma_stainless_steel'
 
   #graphite
-  [./heat_conductor_graphite]
+  [heat_conductor_graphite]
     type = ADHeatConductionMaterial
     thermal_conductivity = 630
     specific_heat = 60
     block = graphite
-  [../]
-  [./rho_graphite]
+  []
+  [rho_graphite]
     type = ADGenericConstantMaterial
     prop_names = 'density'
     prop_values = 1.75e3
     block = graphite
-  [../]
-  [./sigma_graphite]
+  []
+  [sigma_graphite]
     type = ADElectricalConductivity
     temperature = temperature_graphite
     reference_temperature = 293.0
     reference_resistivity = 3.0e-3
     temperature_coefficient = 0 # makes conductivity constant
     block = graphite
-  [../]
+  []
 
   #stainless_steel
-  [./heat_conductor_stainless_steel]
+  [heat_conductor_stainless_steel]
     type = ADHeatConductionMaterial
     thermal_conductivity = 17
     specific_heat = 502
     block = stainless_steel
-  [../]
-  [./rho_stainless_steel]
+  []
+  [rho_stainless_steel]
     type = ADGenericConstantMaterial
     prop_names = 'density'
     prop_values = 8e3
     block = stainless_steel
-  [../]
-  [./sigma_stainless_steel]
+  []
+  [sigma_stainless_steel]
     type = ADElectricalConductivity
     temperature = temperature_stainless_steel
     reference_temperature = 293.0
     reference_resistivity = 7e-7
     temperature_coefficient = 0 # makes conductivity constant
     block = stainless_steel
-  [../]
+  []
 
   # harmonic mean of graphite and stainless steel hardness
-  [./mean_hardness]
+  [mean_hardness]
     type = GraphiteStainlessMeanHardness
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./SMP]
+  [SMP]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/interfacekernels/thermal_conductance/thermal_interface_analytic_solution_two_block.i
+++ b/test/tests/interfacekernels/thermal_conductance/thermal_interface_analytic_solution_two_block.i
@@ -1,131 +1,131 @@
 [Mesh]
-  [./line]
+  [line]
     type = GeneratedMeshGenerator
     xmax = 2
     dim = 1
     nx = 400
-  [../]
-  [./split]
+  []
+  [split]
     type = SubdomainBoundingBoxGenerator
     bottom_left = '0 0 0'
     top_right = '1 0 0'
     block_id = 1
     block_name = 'stainless_steel'
     input = line
-  [../]
-  [./rename_right]
+  []
+  [rename_right]
     type = RenameBlockGenerator
     old_block = 0
     new_block = 'graphite'
     input = split
-  [../]
-  [./interface]
+  []
+  [interface]
     type = SideSetsBetweenSubdomainsGenerator
     input = rename_right
     primary_block = 'stainless_steel'
     paired_block = 'graphite'
     new_boundary = 'ssg_interface'
-  [../]
+  []
 []
 
 [Variables]
-  [./temperature_graphite]
+  [temperature_graphite]
     initial_condition = 300.0
     block = graphite
-  [../]
-  [./temperature_stainless_steel]
+  []
+  [temperature_stainless_steel]
     initial_condition = 300.0
     block = stainless_steel
-  [../]
+  []
 []
 
 [AuxVariables]
-  [./analytic_potential_graphite]
+  [analytic_potential_graphite]
     block = graphite
-  [../]
-  [./analytic_potential_stainless_steel]
+  []
+  [analytic_potential_stainless_steel]
     block = stainless_steel
-  [../]
-  [./analytic_temperature_graphite]
+  []
+  [analytic_temperature_graphite]
     block = graphite
-  [../]
-  [./analytic_temperature_stainless_steel]
+  []
+  [analytic_temperature_stainless_steel]
     block = stainless_steel
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff_graphite]
+  [HeatDiff_graphite]
     type = ADHeatConduction
     variable = temperature_graphite
     block = graphite
-  [../]
-  [./HeatSource_graphite]
+  []
+  [HeatSource_graphite]
     type = ADJouleHeatingSource
     variable = temperature_graphite
     elec = analytic_potential_graphite
     electrical_conductivity = electrical_conductivity
     block = graphite
-  [../]
+  []
 
-  [./HeatDiff_stainless_steel]
+  [HeatDiff_stainless_steel]
     type = ADHeatConduction
     variable = temperature_stainless_steel
     block = stainless_steel
-  [../]
-  [./HeatSource_stainless_steel]
+  []
+  [HeatSource_stainless_steel]
     type = ADJouleHeatingSource
     variable = temperature_stainless_steel
     elec = analytic_potential_stainless_steel
     electrical_conductivity = electrical_conductivity
     block = stainless_steel
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./analytic_potential_function_aux_stainless_steel]
+  [analytic_potential_function_aux_stainless_steel]
     type = FunctionAux
     function = potential_fxn_stainless_steel
     variable = analytic_potential_stainless_steel
     block = stainless_steel
-  [../]
-  [./analytic_potential_function_aux_graphite]
+  []
+  [analytic_potential_function_aux_graphite]
     type = FunctionAux
     function = potential_fxn_graphite
     variable = analytic_potential_graphite
     block = graphite
-  [../]
-  [./analytic_temperature_function_aux_stainless_steel]
+  []
+  [analytic_temperature_function_aux_stainless_steel]
     type = FunctionAux
     function = temperature_fxn_stainless_steel
     variable = analytic_temperature_stainless_steel
     block = stainless_steel
-  [../]
-  [./analytic_temperature_function_aux_graphite]
+  []
+  [analytic_temperature_function_aux_graphite]
     type = FunctionAux
     function = temperature_fxn_graphite
     variable = analytic_temperature_graphite
     block = graphite
-  [../]
+  []
 []
 
 [BCs]
-  [./thermal_left]
+  [thermal_left]
     type = DirichletBC
     variable = temperature_stainless_steel
     boundary = left
     value = 300
-  [../]
-  [./thermal_right]
+  []
+  [thermal_right]
     type = DirichletBC
     variable = temperature_graphite
     boundary = right
     value = 300
-  [../]
+  []
 []
 
 [InterfaceKernels]
-  [./thermal_contact_conductance]
+  [thermal_contact_conductance]
     type = ThermalContactCondition
     variable = temperature_stainless_steel
     neighbor_var = temperature_graphite
@@ -138,63 +138,63 @@
     user_electrical_contact_conductance = 75524 # at 300K with 3 kN/m^2 applied pressure
     user_thermal_contact_conductance = 0.242 # also from Cincotti et al
     boundary = ssg_interface
-  [../]
+  []
 []
 
 [Materials]
   #graphite
-  [./heat_conductor_graphite]
+  [heat_conductor_graphite]
     type = ADGenericConstantMaterial
     prop_names = thermal_conductivity
     prop_values = 100
     block = graphite
-  [../]
-  [./sigma_graphite]
+  []
+  [sigma_graphite]
     type = ADGenericConstantMaterial
     prop_names = electrical_conductivity
     prop_values = 73069.2
     block = graphite
-  [../]
+  []
 
   #stainless_steel
-  [./heat_conductor_stainless_steel]
+  [heat_conductor_stainless_steel]
     type = ADGenericConstantMaterial
     prop_names = thermal_conductivity
     prop_values = 15
     block = stainless_steel
-  [../]
-  [./sigma_stainless_steel]
+  []
+  [sigma_stainless_steel]
     type = ADGenericConstantMaterial
     prop_names = electrical_conductivity
     prop_values = 1.41867e6
     block = stainless_steel
-  [../]
+  []
 []
 
 [Functions]
-  [./potential_fxn_stainless_steel]
+  [potential_fxn_stainless_steel]
     type = ThermalContactPotentialTestFunc
     domain = stainless_steel
-  [../]
-  [./potential_fxn_graphite]
+  []
+  [potential_fxn_graphite]
     type = ThermalContactPotentialTestFunc
     domain = graphite
-  [../]
-  [./temperature_fxn_stainless_steel]
+  []
+  [temperature_fxn_stainless_steel]
     type = ThermalContactTemperatureTestFunc
     domain = stainless_steel
-  [../]
-  [./temperature_fxn_graphite]
+  []
+  [temperature_fxn_graphite]
     type = ThermalContactTemperatureTestFunc
     domain = graphite
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./SMP]
+  [SMP]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]

--- a/test/tests/interfacekernels/thermal_conductance/thermal_interface_mesh.i
+++ b/test/tests/interfacekernels/thermal_conductance/thermal_interface_mesh.i
@@ -2,7 +2,7 @@
 # To generate meshes, select appropriate ix, iy below and use the --mesh-only flag when running this input file.
 
 [Mesh]
-  [./assembly]
+  [assembly]
     type = CartesianMeshGenerator
     dim = 2
     dx = '0.04 0.01'
@@ -18,37 +18,36 @@
                     2 4
                     1 3
                     1 3' # this is the top of the mesh
-  [../]
-  [./create_interface]
+  []
+  [create_interface]
     type = SideSetsBetweenSubdomainsGenerator
     input = assembly
     master_block = 1
     paired_block = 2
     new_boundary = 'ssg_interface'
-
-  [../]
-  [./rename_boundaries]
+  []
+  [rename_boundaries]
     type = RenameBoundaryGenerator
     input = create_interface
     old_boundary_name = 'top bottom'
     new_boundary_name = 'top_die bottom_die'
-  [../]
-  [./rename_blocks]
+  []
+  [rename_blocks]
     type = RenameBlockGenerator
     input = rename_boundaries
     old_block = '1 2'
     new_block = 'stainless_steel graphite'
-  [../]
-  [./rename_stainless_steel_sideset]
+  []
+  [rename_stainless_steel_sideset]
     type = BlockDeletionGenerator
     input = rename_blocks
     block_id = 3
     new_boundary = 'right_stainless_steel'
-  [../]
-  [./rename_graphite_sideset]
+  []
+  [rename_graphite_sideset]
     type = BlockDeletionGenerator
     input = rename_stainless_steel_sideset
     block_id = 4
     new_boundary = 'right_graphite'
-  [../]
+  []
 []


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.

Refs #128 