### PR TITLE
hit formatting of materials input files

### DIFF
--- a/test/tests/materials/graphite/electrical/ad_graphite_electrical_material_properties.i
+++ b/test/tests/materials/graphite/electrical/ad_graphite_electrical_material_properties.i
@@ -22,50 +22,50 @@
 []
 
 [Variables]
-  [./graphite_potential]
-  [../]
+  [graphite_potential]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 713.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./electric_graphite]
+  [electric_graphite]
     type = ADMatDiffusion
     variable = graphite_potential
     diffusivity = electrical_conductivity
-  [../]
+  []
 []
 
 [BCs]
-  [./elec_top]
+  [elec_top]
     type = ADDirichletBC
     variable = graphite_potential
     boundary = top
     value = 10
-  [../]
-  [./elec_bottom]
+  []
+  [elec_bottom]
     type = ADDirichletBC
     variable = graphite_potential
     boundary = bottom
     value = 0
-  [../]
+  []
 []
 
 [Materials]
-  [./graphite_electrical]
+  [graphite_electrical]
     type = ADGraphiteElectricalConductivity
     temperature = temperature
-  [../]
-  [./graphite_electrical_resistivity]
+  []
+  [graphite_electrical_resistivity]
     type = ADParsedMaterial
     property_name = electrical_resistivity
     material_property_names = electrical_conductivity
     expression = '1 / electrical_conductivity'
-  [../]
+  []
 []
 
 [Executioner]
@@ -77,18 +77,17 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_electrical_resistivity]
+  []
+  [max_electrical_resistivity]
     type = ADElementExtremeMaterialProperty
     mat_prop = electrical_resistivity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/graphite/electrical/graphite_electrical_material_properties.i
+++ b/test/tests/materials/graphite/electrical/graphite_electrical_material_properties.i
@@ -22,55 +22,55 @@
 []
 
 [Variables]
-  [./graphite_potential]
-  [../]
+  [graphite_potential]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 713.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./electric_graphite]
+  [electric_graphite]
     type = ADMatDiffusion
     variable = graphite_potential
     diffusivity = ad_electrical_conductivity
-  [../]
+  []
 []
 
 [BCs]
-  [./elec_top]
+  [elec_top]
     type = DirichletBC
     variable = graphite_potential
     boundary = top
     value = 10
-  [../]
-  [./elec_bottom]
+  []
+  [elec_bottom]
     type = DirichletBC
     variable = graphite_potential
     boundary = bottom
     value = 0
-  [../]
+  []
 []
 
 [Materials]
-  [./graphite_electrical]
+  [graphite_electrical]
     type = GraphiteElectricalConductivity
     temperature = temperature
-  [../]
-  [./converter]
+  []
+  [converter]
     type = MaterialADConverter
     reg_props_in = electrical_conductivity
     ad_props_out = ad_electrical_conductivity
-  [../]
-  [./graphite_electrical_resistivity]
+  []
+  [graphite_electrical_resistivity]
     type = ParsedMaterial
     property_name = electrical_resistivity
     material_property_names = electrical_conductivity
     expression = '1 / electrical_conductivity'
-  [../]
+  []
 []
 
 [Executioner]
@@ -82,18 +82,17 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_electrical_resistivity]
+  []
+  [max_electrical_resistivity]
     type = ElementExtremeMaterialProperty
     mat_prop = electrical_resistivity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
@@ -11,91 +11,91 @@
 []
 
 [Mesh]
-  [./mesh]
+  [mesh]
     type = PatchMeshGenerator
     dim = 2
-  [../]
+  []
   coord_type = RZ
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./temp_aux]
+  [temp_aux]
     type = FunctionAux
     variable = temperature
     function = temp_ramp
-  [../]
+  []
 []
 
 [Functions]
-  [./temp_ramp]
+  [temp_ramp]
     type = ParsedFunction
     expression = '300 + 400.0/60.*t' #stand-in for a 400C/min heating rate
-  [../]
-  [./thermal_expansion]
+  []
+  [thermal_expansion]
     type = ParsedFunction
     symbol_names = T
     symbol_values = temperature
     expression = '(1.996e-6*log(T*4.799e-2)-4.041e-6)'
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = ParsedFunction
     symbol_names = 'ref_temperature thermal_expansion temperature'
     symbol_values = '300.0 thermal_expansion temperature'
     expression = 'thermal_expansion * (temperature - ref_temperature)'
-  [../]
+  []
 []
 
 [Physics]
   [SolidMechanics]
     [QuasiStatic]
-      [./all]
+      [all]
         strain = SMALL
         decomposition_method = EigenSolution
         add_variables = true
         use_automatic_differentiation = true
         eigenstrain_names = graphite_thermal_expansion
         generate_output = 'strain_xx'
-      [../]
-    [../]
-  [../]
+      []
+    []
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = ADDirichletBC
     variable = disp_x
     value = 0
     boundary = left
-  [../]
-  [./bottom]
+  []
+  [bottom]
     type = ADDirichletBC
     variable = disp_y
     value = 0
     boundary = bottom
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ADComputeIsotropicElasticityTensor
     youngs_modulus = 1
     poissons_ratio = 0.3
-  [../]
-  [./graphite_thermal_expansion]
+  []
+  [graphite_thermal_expansion]
     type = ADGraphiteThermalExpansionEigenstrain
     eigenstrain_name = graphite_thermal_expansion
     stress_free_temperature = 300
     temperature = temperature
-  [../]
-  [./stress]
+  []
+  [stress]
     type = ADComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -114,31 +114,30 @@
 []
 
 [Postprocessors]
-  [./temperature]
+  [temperature]
     type = ElementAverageValue
     variable = temperature
-  [../]
-  [./strain_xx]
+  []
+  [strain_xx]
     type = ElementAverageValue
     variable = strain_xx
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = FunctionValuePostprocessor
     function = thexp_exact
-  [../]
-  [./thexp_diff]
+  []
+  [thexp_diff]
     type = DifferencePostprocessor
     value1 = strain_xx
     value2 = thexp_exact
     outputs = none
-  [../]
-  [./thexp_max_diff]
+  []
+  [thexp_max_diff]
     type = TimeExtremeValue
     postprocessor = thexp_diff
     value_type = abs_max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
@@ -11,90 +11,90 @@
 []
 
 [Mesh]
-  [./mesh]
+  [mesh]
     type = PatchMeshGenerator
     dim = 2
-  [../]
+  []
   coord_type = RZ
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./temp_aux]
+  [temp_aux]
     type = FunctionAux
     variable = temperature
     function = temp_ramp
-  [../]
+  []
 []
 
 [Functions]
-  [./temp_ramp]
+  [temp_ramp]
     type = ParsedFunction
     expression = '300 + 400.0/60.*t' #stand-in for a 400C/min heating rate
-  [../]
-  [./thermal_expansion]
+  []
+  [thermal_expansion]
     type = ParsedFunction
     symbol_names = T
     symbol_values = temperature
     expression = '(1.996e-6*log(T*4.799e-2)-4.041e-6)'
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = ParsedFunction
     symbol_names = 'ref_temperature thermal_expansion temperature'
     symbol_values = '300.0 thermal_expansion temperature'
     expression = 'thermal_expansion * (temperature - ref_temperature)'
-  [../]
+  []
 []
 
 [Physics]
   [SolidMechanics]
     [QuasiStatic]
-      [./all]
+      [all]
         strain = SMALL
         decomposition_method = EigenSolution
         add_variables = true
         eigenstrain_names = graphite_thermal_expansion
         generate_output = 'strain_xx'
-      [../]
-    [../]
-  [../]
+      []
+    []
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = disp_x
     value = 0
     boundary = left
-  [../]
-  [./bottom]
+  []
+  [bottom]
     type = DirichletBC
     variable = disp_y
     value = 0
     boundary = bottom
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 1
     poissons_ratio = 0.3
-  [../]
-  [./graphite_thermal_expansion]
+  []
+  [graphite_thermal_expansion]
     type = GraphiteThermalExpansionEigenstrain
     eigenstrain_name = graphite_thermal_expansion
     stress_free_temperature = 300
     temperature = temperature
-  [../]
-  [./stress]
+  []
+  [stress]
     type = ComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -111,29 +111,29 @@
 []
 
 [Postprocessors]
-  [./temperature]
+  [temperature]
     type = ElementAverageValue
     variable = temperature
-  [../]
-  [./strain_xx]
+  []
+  [strain_xx]
     type = ElementAverageValue
     variable = strain_xx
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = FunctionValuePostprocessor
     function = thexp_exact
-  [../]
-  [./thexp_diff]
+  []
+  [thexp_diff]
     type = DifferencePostprocessor
     value1 = strain_xx
     value2 = thexp_exact
     outputs = none
-  [../]
-  [./thexp_max_diff]
+  []
+  [thexp_max_diff]
     type = TimeExtremeValue
     postprocessor = thexp_diff
     value_type = abs_max
-  [../]
+  []
 []
 
 [Outputs]

--- a/test/tests/materials/graphite/thermal/ad_graphite_thermal_material_properties.i
+++ b/test/tests/materials/graphite/thermal/ad_graphite_thermal_material_properties.i
@@ -28,44 +28,44 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 500.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff]
+  [HeatDiff]
     type = ADHeatConduction
     variable = temperature
-  [../]
-  [./HeatTdot]
+  []
+  [HeatTdot]
     type = ADHeatConductionTimeDerivative
     variable = temperature
     specific_heat = heat_capacity
     density_name = graphite_density
-  [../]
+  []
 []
 
 [BCs]
-  [./top_surface]
+  [top_surface]
     type = ADFunctionDirichletBC
     boundary = top
     variable = temperature
     function = '500 + 200.0/60.*t' #stand-in for the 200C/min heating rate
-  [../]
+  []
 []
 
 [Materials]
-  [./graphite_thermal]
+  [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
     output_properties = all
-  [../]
-  [./graphite_density]
+  []
+  [graphite_density]
     type = ADGenericConstantMaterial
     prop_names = 'graphite_density'
     prop_values = 1.750e3 #in kg/m^3 from Cincotti et al 2007, Table 2, doi:10.1002/aic
-  [../]
+  []
 []
 
 [Executioner]
@@ -83,23 +83,22 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_thermal_conductivity]
+  []
+  [max_thermal_conductivity]
     type = ADElementExtremeMaterialProperty
     mat_prop = thermal_conductivity
     value_type = max
-  [../]
-  [./max_heat_capacity]
+  []
+  [max_heat_capacity]
     type = ADElementExtremeMaterialProperty
     mat_prop = heat_capacity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/graphite/thermal/graphite_thermal_material_properties.i
+++ b/test/tests/materials/graphite/thermal/graphite_thermal_material_properties.i
@@ -28,44 +28,44 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 500.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff]
+  [HeatDiff]
     type = ADHeatConduction
     variable = temperature
-  [../]
-  [./HeatTdot]
+  []
+  [HeatTdot]
     type = ADHeatConductionTimeDerivative
     variable = temperature
     specific_heat = heat_capacity
     density_name = graphite_density
-  [../]
+  []
 []
 
 [BCs]
-  [./top_surface]
+  [top_surface]
     type = ADFunctionDirichletBC
     boundary = top
     variable = temperature
     function = '500 + 200.0/60.*t' #stand-in for the 200C/min heating rate
-  [../]
+  []
 []
 
 [Materials]
-  [./graphite_thermal]
+  [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
     output_properties = all
-  [../]
-  [./graphite_density]
+  []
+  [graphite_density]
     type = ADGenericConstantMaterial
     prop_names = 'graphite_density'
     prop_values = 1.750e3 #in kg/m^3 from Cincotti et al 2007, Table 2, doi:10.1002/aic
-  [../]
+  []
 []
 
 [Executioner]
@@ -83,21 +83,21 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_thermal_conductivity]
+  []
+  [max_thermal_conductivity]
     type = ADElementExtremeMaterialProperty
     mat_prop = thermal_conductivity
     value_type = max
-  [../]
-  [./max_heat_capacity]
+  []
+  [max_heat_capacity]
     type = ADElementExtremeMaterialProperty
     mat_prop = heat_capacity
     value_type = max
-  [../]
+  []
 []
 
 [Outputs]

--- a/test/tests/materials/stainless_steel/electrical/ad_stainless_steel_electrical_material_properties.i
+++ b/test/tests/materials/stainless_steel/electrical/ad_stainless_steel_electrical_material_properties.i
@@ -22,50 +22,50 @@
 []
 
 [Variables]
-  [./stainless_steel_potential]
-  [../]
+  [stainless_steel_potential]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 573.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./electric_stainless_steel]
+  [electric_stainless_steel]
     type = ADMatDiffusion
     variable = stainless_steel_potential
     diffusivity = electrical_conductivity
-  [../]
+  []
 []
 
 [BCs]
-  [./elec_top]
+  [elec_top]
     type = ADDirichletBC
     variable = stainless_steel_potential
     boundary = top
     value = 10
-  [../]
-  [./elec_bottom]
+  []
+  [elec_bottom]
     type = ADDirichletBC
     variable = stainless_steel_potential
     boundary = bottom
     value = 0
-  [../]
+  []
 []
 
 [Materials]
-  [./stainless_steel_electrical]
+  [stainless_steel_electrical]
     type = ADStainlessSteelElectricalConductivity
     temperature = temperature
-  [../]
-  [./stainless_steel_electrical_resistivity]
+  []
+  [stainless_steel_electrical_resistivity]
     type = ADParsedMaterial
     property_name = electrical_resistivity
     material_property_names = electrical_conductivity
     expression = '1 / electrical_conductivity'
-  [../]
+  []
 []
 
 [Executioner]
@@ -77,18 +77,17 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_electrical_resistivity]
+  []
+  [max_electrical_resistivity]
     type = ADElementExtremeMaterialProperty
     mat_prop = electrical_resistivity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/stainless_steel/electrical/stainless_steel_electrical_material_properties.i
+++ b/test/tests/materials/stainless_steel/electrical/stainless_steel_electrical_material_properties.i
@@ -22,55 +22,55 @@
 []
 
 [Variables]
-  [./stainless_steel_potential]
-  [../]
+  [stainless_steel_potential]
+  []
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 573.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./electric_stainless_steel]
+  [electric_stainless_steel]
     type = ADMatDiffusion
     variable = stainless_steel_potential
     diffusivity = ad_electrical_conductivity
-  [../]
+  []
 []
 
 [BCs]
-  [./elec_top]
+  [elec_top]
     type = DirichletBC
     variable = stainless_steel_potential
     boundary = top
     value = 10
-  [../]
-  [./elec_bottom]
+  []
+  [elec_bottom]
     type = DirichletBC
     variable = stainless_steel_potential
     boundary = bottom
     value = 0
-  [../]
+  []
 []
 
 [Materials]
-  [./stainless_steel_electrical]
+  [stainless_steel_electrical]
     type = StainlessSteelElectricalConductivity
     temperature = temperature
-  [../]
-  [./converter]
+  []
+  [converter]
     type = MaterialADConverter
     reg_props_in = electrical_conductivity
     ad_props_out = ad_electrical_conductivity
-  [../]
-  [./stainless_steel_electrical_resistivity]
+  []
+  [stainless_steel_electrical_resistivity]
     type = ParsedMaterial
     property_name = electrical_resistivity
     material_property_names = electrical_conductivity
     expression = '1 / electrical_conductivity'
-  [../]
+  []
 []
 
 [Executioner]
@@ -82,18 +82,17 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_electrical_resistivity]
+  []
+  [max_electrical_resistivity]
     type = ElementExtremeMaterialProperty
     mat_prop = electrical_resistivity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
@@ -10,91 +10,91 @@
 []
 
 [Mesh]
-  [./mesh]
+  [mesh]
     type = PatchMeshGenerator
     dim = 2
-  [../]
+  []
   coord_type = RZ
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./temp_aux]
+  [temp_aux]
     type = FunctionAux
     variable = temperature
     function = temp_ramp
-  [../]
+  []
 []
 
 [Functions]
-  [./temp_ramp]
+  [temp_ramp]
     type = ParsedFunction
     expression = '300 + 100.0/60.*t' #stand-in for a 100C/min heating rate
-  [../]
-  [./thermal_expansion]
+  []
+  [thermal_expansion]
     type = ParsedFunction
     symbol_names = T
     symbol_values = temperature
     expression = 'if(T>588, (1.84e-5), if(T>373, (1.78e-5), (1.72e-5)))'
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = ParsedFunction
     symbol_names = 'ref_temperature thermal_expansion temperature'
     symbol_values = '300.0 thermal_expansion temperature'
     expression = 'thermal_expansion * (temperature - ref_temperature)'
-  [../]
+  []
 []
 
 [Physics]
   [SolidMechanics]
     [QuasiStatic]
-      [./all]
+      [all]
         strain = SMALL
         decomposition_method = EigenSolution
         add_variables = true
         use_automatic_differentiation = true
         eigenstrain_names = stainless_steel_thermal_expansion
         generate_output = 'strain_xx'
-      [../]
-    [../]
-  [../]
+      []
+    []
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = ADDirichletBC
     variable = disp_x
     value = 0
     boundary = left
-  [../]
-  [./bottom]
+  []
+  [bottom]
     type = ADDirichletBC
     variable = disp_y
     value = 0
     boundary = bottom
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ADComputeIsotropicElasticityTensor
     youngs_modulus = 1
     poissons_ratio = 0.3
-  [../]
-  [./stainless_steel_thermal_expansion]
+  []
+  [stainless_steel_thermal_expansion]
     type = ADStainlessSteelThermalExpansionEigenstrain
     eigenstrain_name = stainless_steel_thermal_expansion
     stress_free_temperature = 300
     temperature = temperature
-  [../]
-  [./stress]
+  []
+  [stress]
     type = ADComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -113,31 +113,30 @@
 []
 
 [Postprocessors]
-  [./temperature]
+  [temperature]
     type = ElementAverageValue
     variable = temperature
-  [../]
-  [./strain_xx]
+  []
+  [strain_xx]
     type = ElementAverageValue
     variable = strain_xx
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = FunctionValuePostprocessor
     function = thexp_exact
-  [../]
-  [./thexp_diff]
+  []
+  [thexp_diff]
     type = DifferencePostprocessor
     value1 = strain_xx
     value2 = thexp_exact
     outputs = none
-  [../]
-  [./thexp_max_diff]
+  []
+  [thexp_max_diff]
     type = TimeExtremeValue
     postprocessor = thexp_diff
     value_type = abs_max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
@@ -11,90 +11,90 @@
 []
 
 [Mesh]
-  [./mesh]
+  [mesh]
     type = PatchMeshGenerator
     dim = 2
-  [../]
+  []
   coord_type = RZ
 []
 
 [AuxVariables]
-  [./temperature]
+  [temperature]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [AuxKernels]
-  [./temp_aux]
+  [temp_aux]
     type = FunctionAux
     variable = temperature
     function = temp_ramp
-  [../]
+  []
 []
 
 [Functions]
-  [./temp_ramp]
+  [temp_ramp]
     type = ParsedFunction
     expression = '300 + 100.0/60.*t' #stand-in for a 100C/min heating rate
-  [../]
-  [./thermal_expansion]
+  []
+  [thermal_expansion]
     type = ParsedFunction
     symbol_names = T
     symbol_values = temperature
     expression = 'if(T>588, (1.84e-5), if(T>373, (1.78e-5), (1.72e-5)))'
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = ParsedFunction
     symbol_names = 'ref_temperature thermal_expansion temperature'
     symbol_values = '300.0 thermal_expansion temperature'
     expression = 'thermal_expansion * (temperature - ref_temperature)'
-  [../]
+  []
 []
 
 [Physics]
   [SolidMechanics]
     [QuasiStatic]
-      [./all]
+      [all]
         strain = SMALL
         decomposition_method = EigenSolution
         add_variables = true
         eigenstrain_names = stainless_steel_thermal_expansion
         generate_output = 'strain_xx'
-      [../]
-    [../]
-  [../]
+      []
+    []
+  []
 []
 
 [BCs]
-  [./left]
+  [left]
     type = DirichletBC
     variable = disp_x
     value = 0
     boundary = left
-  [../]
-  [./bottom]
+  []
+  [bottom]
     type = DirichletBC
     variable = disp_y
     value = 0
     boundary = bottom
-  [../]
+  []
 []
 
 [Materials]
-  [./elasticity_tensor]
+  [elasticity_tensor]
     type = ComputeIsotropicElasticityTensor
     youngs_modulus = 1
     poissons_ratio = 0.3
-  [../]
-  [./stainless_steel_thermal_expansion]
+  []
+  [stainless_steel_thermal_expansion]
     type = StainlessSteelThermalExpansionEigenstrain
     eigenstrain_name = stainless_steel_thermal_expansion
     stress_free_temperature = 300
     temperature = temperature
-  [../]
-  [./stress]
+  []
+  [stress]
     type = ComputeLinearElasticStress
-  [../]
+  []
 []
 
 [Executioner]
@@ -111,31 +111,30 @@
 []
 
 [Postprocessors]
-  [./temperature]
+  [temperature]
     type = ElementAverageValue
     variable = temperature
-  [../]
-  [./strain_xx]
+  []
+  [strain_xx]
     type = ElementAverageValue
     variable = strain_xx
-  [../]
-  [./thexp_exact]
+  []
+  [thexp_exact]
     type = FunctionValuePostprocessor
     function = thexp_exact
-  [../]
-  [./thexp_diff]
+  []
+  [thexp_diff]
     type = DifferencePostprocessor
     value1 = strain_xx
     value2 = thexp_exact
     outputs = none
-  [../]
-  [./thexp_max_diff]
+  []
+  [thexp_max_diff]
     type = TimeExtremeValue
     postprocessor = thexp_diff
     value_type = abs_max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/stainless_steel/thermal/ad_stainless_steel_thermal_material_properties.i
+++ b/test/tests/materials/stainless_steel/thermal/ad_stainless_steel_thermal_material_properties.i
@@ -27,44 +27,44 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 350.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff]
+  [HeatDiff]
     type = ADHeatConduction
     variable = temperature
-  [../]
-  [./HeatTdot]
+  []
+  [HeatTdot]
     type = ADHeatConductionTimeDerivative
     variable = temperature
     specific_heat = heat_capacity
     density_name = stainless_steel_density
-  [../]
+  []
 []
 
 [BCs]
-  [./top_surface]
+  [top_surface]
     type = ADFunctionDirichletBC
     boundary = top
     variable = temperature
     function = '350 + 100.0/60.*t' #stand-in for the 100C/min heating rate
-  [../]
+  []
 []
 
 [Materials]
-  [./stainless_steel_thermal]
+  [stainless_steel_thermal]
     type = ADStainlessSteelThermal
     temperature = temperature
     output_properties = all
-  [../]
-  [./stainless_steel_density]
+  []
+  [stainless_steel_density]
     type = ADGenericConstantMaterial
     prop_names = 'stainless_steel_density'
     prop_values = 8.0e3 #in kg/m^3 from Cincotti et al 2007, Table 2, doi:10.1002/aic
-  [../]
+  []
 []
 
 [Executioner]
@@ -82,21 +82,21 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_thermal_conductivity]
+  []
+  [max_thermal_conductivity]
     type = ADElementExtremeMaterialProperty
     mat_prop = thermal_conductivity
     value_type = max
-  [../]
-  [./max_heat_capacity]
+  []
+  [max_heat_capacity]
     type = ADElementExtremeMaterialProperty
     mat_prop = heat_capacity
     value_type = max
-  [../]
+  []
 []
 
 [Outputs]

--- a/test/tests/materials/stainless_steel/thermal/stainless_steel_thermal_material_properties.i
+++ b/test/tests/materials/stainless_steel/thermal/stainless_steel_thermal_material_properties.i
@@ -27,45 +27,45 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 350.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff]
+  [HeatDiff]
     type = HeatConduction
     variable = temperature
     diffusion_coefficient = thermal_conductivity
-  [../]
-  [./HeatTdot]
+  []
+  [HeatTdot]
     type = HeatConductionTimeDerivative
     variable = temperature
     specific_heat = heat_capacity
     density_name = stainless_steel_density
-  [../]
+  []
 []
 
 [BCs]
-  [./top_surface]
+  [top_surface]
     type = FunctionDirichletBC
     boundary = top
     variable = temperature
     function = '350 + 100.0/60.*t' #stand-in for the 100C/min heating rate
-  [../]
+  []
 []
 
 [Materials]
-  [./stainless_steel_thermal]
+  [stainless_steel_thermal]
     type = StainlessSteelThermal
     temperature = temperature
     output_properties = all
-  [../]
-  [./stainless_steel_density]
+  []
+  [stainless_steel_density]
     type = GenericConstantMaterial
     prop_names = 'stainless_steel_density'
     prop_values = 8.0e3 #in kg/m^3 from Cincotti et al 2007, Table 2, doi:10.1002/aic
-  [../]
+  []
 []
 
 [Executioner]
@@ -83,23 +83,22 @@
 []
 
 [Postprocessors]
-  [./max_temperature]
+  [max_temperature]
     type = NodalExtremeValue
     variable = temperature
     value_type = max
-  [../]
-  [./max_thermal_conductivity]
+  []
+  [max_thermal_conductivity]
     type = ElementExtremeMaterialProperty
     mat_prop = thermal_conductivity
     value_type = max
-  [../]
-  [./max_heat_capacity]
+  []
+  [max_heat_capacity]
     type = ElementExtremeMaterialProperty
     mat_prop = heat_capacity
     value_type = max
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true

--- a/test/tests/materials/yttria/yittra_only_engineering_scale.i
+++ b/test/tests/materials/yttria/yittra_only_engineering_scale.i
@@ -62,8 +62,8 @@
     type = DerivativeParsedMaterial
     property_name = yttria_specific_heat_capacity
     coupled_variables = 'temperature'
-    constant_names = 'molar_mass    gtokg'
-    constant_expressions = '225.81         1.0e3' #
+    constant_names =        'molar_mass    gtokg'
+    constant_expressions =  '225.81         1.0e3' #
     expression = 'if(temperature<1503.7, (3.0183710318246e-19 * temperature^7 - 2.03644357435399e-15 * temperature^6
                               + 5.75283959486472e-12 * temperature^5 - 8.8224198737065e-09 * temperature^4
                               + 7.96030446457309e-06  * temperature^3 - 0.00427362972278911 * temperature^2

--- a/test/tests/materials/yttria/yittra_only_engineering_scale.i
+++ b/test/tests/materials/yttria/yittra_only_engineering_scale.i
@@ -12,27 +12,27 @@
 []
 
 [Variables]
-  [./temperature]
+  [temperature]
     initial_condition = 300.0
-  [../]
+  []
 []
 
 [Kernels]
-  [./HeatDiff]
+  [HeatDiff]
     type = HeatConduction
     variable = temperature
     diffusion_coefficient = yttria_thermal_conductivity
-  [../]
-  [./HeatTdot]
+  []
+  [HeatTdot]
     type = SpecificHeatConductionTimeDerivative
     variable = temperature
     specific_heat = yttria_specific_heat_capacity
     density = yttria_density
-  [../]
+  []
 []
 
 [BCs]
-  [./external_surface]
+  [external_surface]
     type = InfiniteCylinderRadiativeBC
     boundary = right
     variable = temperature
@@ -40,30 +40,30 @@
     boundary_radius = 0.01
     cylinder_radius = 1
     boundary_emissivity = 0.9
-  [../]
-  [./top_surface]
+  []
+  [top_surface]
     type = FunctionDirichletBC
     boundary = top
     variable = temperature
     function = '293 + 100.0/60.*t' #stand-in for the 100C/min heating rate
-  [../]
+  []
 []
 
 [Materials]
-  [./yttria_thermal_conductivity]
+  [yttria_thermal_conductivity]
     type = ParsedMaterial
     coupled_variables = 'temperature'
     expression = '3214.46 / (temperature - 147.73)' #in W/(m-K)
     property_name = 'yttria_thermal_conductivity'
     output_properties = yttria_thermal_conductivity
     outputs = 'csv exodus'
-  [../]
-  [./yttria_specific_heat_capacity]
+  []
+  [yttria_specific_heat_capacity]
     type = DerivativeParsedMaterial
     property_name = yttria_specific_heat_capacity
     coupled_variables = 'temperature'
-    constant_names =        'molar_mass    gtokg'
-    constant_expressions =  '225.81         1.0e3' #
+    constant_names = 'molar_mass    gtokg'
+    constant_expressions = '225.81         1.0e3' #
     expression = 'if(temperature<1503.7, (3.0183710318246e-19 * temperature^7 - 2.03644357435399e-15 * temperature^6
                               + 5.75283959486472e-12 * temperature^5 - 8.8224198737065e-09 * temperature^4
                               + 7.96030446457309e-06  * temperature^3 - 0.00427362972278911 * temperature^2
@@ -71,19 +71,19 @@
                   (0.0089*temperature + 119.59) / molar_mass * gtokg)' #in J/(K-kg)
     output_properties = yttria_specific_heat_capacity
     outputs = 'csv exodus'
-  [../]
-  [./yttria_density]
+  []
+  [yttria_density]
     type = GenericConstantMaterial
     prop_names = 'yttria_density'
     prop_values = 5.01e3 #in kg/m^3, 5.01 g/cm^3
-  [../]
+  []
 []
 
 [Preconditioning]
-  [./SMP]
+  [SMP]
     type = SMP
     full = true
-  [../]
+  []
 []
 
 [Executioner]
@@ -104,20 +104,19 @@
 []
 
 [Postprocessors]
-  [./temperature]
+  [temperature]
     type = AverageNodalVariableValue
     variable = temperature
-  [../]
-  [./yttria_thermal_conductivity]
+  []
+  [yttria_thermal_conductivity]
     type = ElementAverageValue
     variable = yttria_thermal_conductivity
-  [../]
-  [./yttria_specific_heat_capacity]
+  []
+  [yttria_specific_heat_capacity]
     type = ElementAverageValue
     variable = yttria_specific_heat_capacity
-  [../]
+  []
 []
-
 
 [Outputs]
   csv = true


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.
Refs #128 