### PR TITLE
hit formatting of melt pool heat input files

### DIFF
--- a/test/tests/melt_pool_heat/heat.i
+++ b/test/tests/melt_pool_heat/heat.i
@@ -1,13 +1,15 @@
-[Mesh/gen]
-  type = GeneratedMeshGenerator
-  dim = 2
-  xmin = 0
-  xmax = 1
-  ymin = 0
-  ymax = 1
-  nx = 40
-  ny = 40
-  elem_type = QUAD4
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 1
+    ymin = 0
+    ymax = 1
+    nx = 40
+    ny = 40
+    elem_type = QUAD4
+  []
 []
 
 [ICs]
@@ -27,14 +29,18 @@
   []
 []
 
-[AuxVariables/ls]
+[AuxVariables]
+  [ls]
+  []
 []
 
-[Functions/ls_exact]
-   type = LevelSetOlssonPlane
-   epsilon = 0.04
-   point = '0.5 0.5 0'
-   normal = '0 1 0'
+[Functions]
+  [ls_exact]
+    type = LevelSetOlssonPlane
+    epsilon = 0.04
+    point = '0.5 0.5 0'
+    normal = '0 1 0'
+  []
 []
 
 [Kernels]
@@ -78,7 +84,7 @@
 [Materials]
   [thermal]
     type = ADGenericConstantMaterial
-    prop_names  = 'rho thermal_conductivity specific_heat melt_pool_mass_rate'
+    prop_names = 'rho thermal_conductivity specific_heat melt_pool_mass_rate'
     prop_values = '8000 50 500 0'
   []
   [delta]

--- a/test/tests/melt_pool_heat/thermal_material.i
+++ b/test/tests/melt_pool_heat/thermal_material.i
@@ -1,13 +1,15 @@
-[Mesh/gen]
-  type = GeneratedMeshGenerator
-  dim = 2
-  xmin = 0
-  xmax = 1
-  ymin = 0
-  ymax = 1
-  nx = 40
-  ny = 40
-  elem_type = QUAD4
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 1
+    ymin = 0
+    ymax = 1
+    nx = 40
+    ny = 40
+    elem_type = QUAD4
+  []
 []
 
 [ICs]
@@ -32,19 +34,21 @@
   []
 []
 
-[Functions/ls_exact]
-   type = LevelSetOlssonPlane
-   epsilon = 0.04
-   point = '0.5 0.5 0'
-   normal = '0 1 0'
+[Functions]
+  [ls_exact]
+    type = LevelSetOlssonPlane
+    epsilon = 0.04
+    point = '0.5 0.5 0'
+    normal = '0 1 0'
+  []
 []
 
 [Kernels]
-  [./grad_ls]
+  [grad_ls]
     type = VariableGradientRegularization
     regularized_var = ls
     variable = grad_ls
-  [../]
+  []
 
   [heat_time]
     type = ADHeatConductionTimeDerivative
@@ -100,7 +104,7 @@
   []
   [rho]
     type = ADGenericConstantMaterial
-    prop_names  = 'rho melt_pool_mass_rate'
+    prop_names = 'rho melt_pool_mass_rate'
     prop_values = '8000 0'
   []
   [heaviside]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.
Refs #128