### PR TITLE
hit formatting of melt pool level set input files

### DIFF
--- a/test/tests/melt_pool_level_set/level_set.i
+++ b/test/tests/melt_pool_level_set/level_set.i
@@ -50,11 +50,13 @@
   []
 []
 
-[Functions/ls_exact]
-   type = LevelSetOlssonPlane
-   epsilon = 0.0002
-   point = '0.005 0.005 0'
-   normal = '0 1 0'
+[Functions]
+  [ls_exact]
+    type = LevelSetOlssonPlane
+    epsilon = 0.0002
+    point = '0.005 0.005 0'
+    normal = '0 1 0'
+  []
 []
 
 [BCs]

--- a/test/tests/melt_pool_level_set/reinit.i
+++ b/test/tests/melt_pool_level_set/reinit.i
@@ -1,13 +1,15 @@
-[Mesh/gen]
-  type = GeneratedMeshGenerator
-  dim = 2
-  xmin = 0
-  xmax = 0.01
-  ymin = 0
-  ymax = 0.01
-  nx = 50
-  ny = 50
-  elem_type = QUAD4
+[Mesh]
+  [gen]
+    type = GeneratedMeshGenerator
+    dim = 2
+    xmin = 0
+    xmax = 0.01
+    ymin = 0
+    ymax = 0.01
+    nx = 50
+    ny = 50
+    elem_type = QUAD4
+  []
 []
 
 [Variables]


### PR DESCRIPTION
Performed comparison between the two csv files, one that was the original and another that received hit formatting, to ensure that the results were the same. Also ensured that comments were formatted correctly in the input files.
Refs #128 