### PR TITLE
Forward compatibility patch

### DIFF
--- a/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/cylinder/master_app_mechanical.i
@@ -132,8 +132,7 @@ dt = 200
     [QuasiStatic]
       strain = FINITE
       incremental = true
-      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
-                        'strain_zz strain_xy strain_xz strain_yz'
+      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx strain_zz strain_xy strain_xz strain_yz'
       use_automatic_differentiation = true
       [product]
         block = '2'
@@ -241,7 +240,7 @@ dt = 200
   []
 []
 
-[UserObjects]
+[MeshModifiers]
   [activated_elem_uo_beam]
     type = CoupledVarThresholdElementSubdomainModifier
     execute_on = 'TIMESTEP_BEGIN'
@@ -250,8 +249,9 @@ dt = 200
     subdomain_id = 2
     criterion_type = ABOVE
     threshold = ${T_melt}
-    moving_boundary_name = 'moving_boundary'
-    apply_initial_conditions = false
+    moving_boundaries = 'moving_boundary'
+    moving_boundary_subdomain_pairs = '2 1'
+    reinitialize_subdomains = ''
   []
 []
 
@@ -286,8 +286,7 @@ dt = 200
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options_iname = '-ksp_type -pc_type -pc_factor_mat_solver_package -pc_factor_shift_type '
-                        '-pc_factor_shift_amount'
+  petsc_options_iname = '-ksp_type -pc_type -pc_factor_mat_solver_package -pc_factor_shift_type -pc_factor_shift_amount'
   petsc_options_value = 'preonly lu       superlu_dist NONZERO 1e-10'
 
   line_search = 'none'

--- a/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/cylinder/sub_app_thermal.i
@@ -244,7 +244,7 @@ dt = 200
   []
 []
 
-[UserObjects]
+[MeshModifiers]
   [activated_elem_uo_beam]
     type = CoupledVarThresholdElementSubdomainModifier
     execute_on = 'TIMESTEP_BEGIN'
@@ -253,7 +253,8 @@ dt = 200
     subdomain_id = 2
     criterion_type = ABOVE
     threshold = ${T_melt}
-    moving_boundary_name = 'moving_boundary'
+    moving_boundaries = 'moving_boundary'
+    moving_boundary_subdomain_pairs = '2 1'
   []
 []
 

--- a/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/master_app_mechanical.i
@@ -132,8 +132,7 @@ dt = 20
     [QuasiStatic]
       strain = FINITE
       incremental = true
-      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx '
-                        'strain_zz strain_xy strain_xz strain_yz'
+      generate_output = 'stress_xx stress_yy stress_zz stress_xy stress_yz stress_xz strain_yy strain_xx strain_zz strain_xy strain_xz strain_yz'
       use_automatic_differentiation = true
       [product]
         block = '2'
@@ -241,7 +240,7 @@ dt = 20
   []
 []
 
-[UserObjects]
+[MeshModifiers]
   [activated_elem_uo_beam]
     type = CoupledVarThresholdElementSubdomainModifier
     execute_on = 'TIMESTEP_BEGIN'
@@ -250,8 +249,9 @@ dt = 20
     subdomain_id = 2
     criterion_type = ABOVE
     threshold = ${T_melt}
-    moving_boundary_name = 'moving_boundary'
-    apply_initial_conditions = false
+    moving_boundaries = 'moving_boundary'
+    moving_boundary_subdomain_pairs = '2 1'
+    reinitialize_subdomains = ''
   []
 []
 
@@ -286,8 +286,7 @@ dt = 20
   type = Transient
   solve_type = 'NEWTON'
 
-  petsc_options_iname = '-ksp_type -pc_type -pc_factor_mat_solver_package -pc_factor_shift_type '
-                        '-pc_factor_shift_amount'
+  petsc_options_iname = '-ksp_type -pc_type -pc_factor_mat_solver_package -pc_factor_shift_type -pc_factor_shift_amount'
   petsc_options_value = 'preonly lu       superlu_dist NONZERO 1e-10'
 
   line_search = 'none'

--- a/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
+++ b/examples/directed_energy_deposition/hollow_cylinder/sub_app_thermal.i
@@ -249,7 +249,7 @@ dt = 20
   []
 []
 
-[UserObjects]
+[MeshModifiers]
   [activated_elem_uo_beam]
     type = CoupledVarThresholdElementSubdomainModifier
     execute_on = 'TIMESTEP_BEGIN'
@@ -258,7 +258,8 @@ dt = 20
     subdomain_id = 2
     criterion_type = ABOVE
     threshold = ${T_melt}
-    moving_boundary_name = 'moving_boundary'
+    moving_boundaries = 'moving_boundary'
+    moving_boundary_subdomain_pairs = '2 1'
   []
 []
 


### PR DESCRIPTION
This updates the directed energy deposition examples to match the changes that will be made to `CoupledVarThresholdElementSubdomainModifier` in the https://github.com/idaholab/moose/pull/27965 pull request. The `apply_initial_conditions` parameter has been replaced by `reinitialize_subdomains`, and the `moving_boundary_name` parameter has been replaced by `moving_boundaries` and `moving_boundary_subdomain_pairs`. Also has been updated to keep up with https://github.com/idaholab/moose/pull/28314.

@sapitts @cticenhour