### PR TITLE
Fixup deprecated failures

### DIFF
--- a/examples/sps/microstructure/sps_elec_2D_YOvac.i
+++ b/examples/sps/microstructure/sps_elec_2D_YOvac.i
@@ -430,23 +430,23 @@
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/microstructure/sps_elec_2D_YOvac_T.i
+++ b/examples/sps/microstructure/sps_elec_2D_YOvac_T.i
@@ -460,23 +460,23 @@
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/micro_yttria_thermoelectric_oneway_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/oneway_controls/micro_yttria_thermoelectric_oneway_controls.i
@@ -465,23 +465,23 @@ initial_field = 10 #from the engineering scale, starting value 10 V/m
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/micro_yttria_thermoelectric_twoway.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_initial_prototype/micro_yttria_thermoelectric_twoway.i
@@ -513,23 +513,23 @@ initial_voltage = 0.0001
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/micro_yttria_thermoelectric_twoway_lots_controls.i
+++ b/examples/sps/multiapp/electrothermal_with_phase_field/twoway_lots_of_particles_prototype/micro_yttria_thermoelectric_twoway_lots_controls.i
@@ -510,23 +510,23 @@ initial_voltage = 0.0001
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/multiapp/yttria_thermoelectric/reference_residual/function_electricpotential/fourparticle/fourparticle_micro_yttria_thermoelectric_twoway.i
+++ b/examples/sps/multiapp/yttria_thermoelectric/reference_residual/function_electricpotential/fourparticle/fourparticle_micro_yttria_thermoelectric_twoway.i
@@ -506,23 +506,23 @@ initial_voltage=0.0001
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   [../]
   [./potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   [../]
   [./potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   [../]
   [./potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   [../]
   [./Laplace_dV]
     type = MatDiffusion

--- a/examples/sps/multiapp/yttria_thermoelectric/reference_residual/function_electricpotential/micro_yttria_thermoelectric_oneway.i
+++ b/examples/sps/multiapp/yttria_thermoelectric/reference_residual/function_electricpotential/micro_yttria_thermoelectric_oneway.i
@@ -432,23 +432,23 @@ initial_field = 10 #from the engineering scale, starting value 10 V/m
     type = MatReaction
     variable = V
     v = wvy
-    mob_name = cat_mu_pre
+    reaction_rate = cat_mu_pre
   []
   [potential_an_mu]
     type = MatReaction
     variable = V
     v = wvo
-    mob_name = an_mu_pre
+    reaction_rate = an_mu_pre
   []
   [potential_cat_V]
     type = MatReaction
     variable = V
-    mob_name = cat_V_pre
+    reaction_rate = cat_V_pre
   []
   [potential_an_V]
     type = MatReaction
     variable = V
-    mob_name = an_V_pre
+    reaction_rate = an_V_pre
   []
   [Laplace_dV]
     type = MatDiffusion

--- a/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/ad_graphite_thermal_expansion.i
@@ -12,7 +12,7 @@
 
 [Mesh]
   [mesh]
-    type = PatchMeshGenerator
+    type = ExamplePatchMeshGenerator
     dim = 2
   []
   coord_type = RZ

--- a/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
+++ b/test/tests/materials/graphite/mechanical/graphite_thermal_expansion.i
@@ -12,7 +12,7 @@
 
 [Mesh]
   [mesh]
-    type = PatchMeshGenerator
+    type = ExamplePatchMeshGenerator
     dim = 2
   []
   coord_type = RZ

--- a/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/ad_stainless_steel_thermal_expansion.i
@@ -11,7 +11,7 @@
 
 [Mesh]
   [mesh]
-    type = PatchMeshGenerator
+    type = ExamplePatchMeshGenerator
     dim = 2
   []
   coord_type = RZ

--- a/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
+++ b/test/tests/materials/stainless_steel/mechanical/stainless_steel_thermal_expansion.i
@@ -12,7 +12,7 @@
 
 [Mesh]
   [mesh]
-    type = PatchMeshGenerator
+    type = ExamplePatchMeshGenerator
     dim = 2
   []
   coord_type = RZ

--- a/test/tests/melt_pool_mass/tests
+++ b/test/tests/melt_pool_mass/tests
@@ -3,6 +3,7 @@
   [mass]
     type = 'Exodiff'
     input = 'mass.i'
+    abs_zero = 6e-10   # Adjusted for Apple Silicon systems
     exodiff = 'mass_out.e'
     design = 'LevelSetPowderAddition.md'
     requirement = 'The system shall evolve the level set variable field with the velocity due to the powder addition.'

--- a/test/tests/melt_pool_mass/tests
+++ b/test/tests/melt_pool_mass/tests
@@ -3,7 +3,7 @@
   [mass]
     type = 'Exodiff'
     input = 'mass.i'
-    abs_zero = 6e-10   # Adjusted for Apple Silicon systems
+    abs_zero = 6e-10   # Adjusted due to failure on Apple Silicon systems
     exodiff = 'mass_out.e'
     design = 'LevelSetPowderAddition.md'
     requirement = 'The system shall evolve the level set variable field with the velocity due to the powder addition.'


### PR DESCRIPTION
Closes #171 

There was also a failure on Apple Silicon systems noticed with the `melt_pool_mass/mass` test. The failing values were on the order of `1.e-10`, so the absolute zero level was adjusted to satisfy the Exodiff tester. Refs #35.