### PR TITLE
Divert material output to CSV object when it is needed by postprocessor

### DIFF
--- a/test/tests/materials/yttria/yittra_only_engineering_scale.i
+++ b/test/tests/materials/yttria/yittra_only_engineering_scale.i
@@ -56,7 +56,7 @@
     expression = '3214.46 / (temperature - 147.73)' #in W/(m-K)
     property_name = 'yttria_thermal_conductivity'
     output_properties = yttria_thermal_conductivity
-    outputs = 'exodus'
+    outputs = 'csv'
   []
   [yttria_specific_heat_capacity]
     type = DerivativeParsedMaterial
@@ -70,7 +70,7 @@
                               + 1.30756778141995 * temperature - 61.6301212149735) / molar_mass * gtokg,
                   (0.0089*temperature + 119.59) / molar_mass * gtokg)' #in J/(K-kg)
     output_properties = yttria_specific_heat_capacity
-    outputs = 'exodus'
+    outputs = 'csv'
   []
   [yttria_density]
     type = GenericConstantMaterial
@@ -120,6 +120,5 @@
 
 [Outputs]
   csv = true
-  exodus = true
   perf_graph = true
 []


### PR DESCRIPTION
refs #182

Based on the conversation in https://github.com/idaholab/moose/pull/29820, I now have a better idea of the materials output system, and it turns out the fix in #183 was not fully solving the issue of outputting material properties in a CSVDiff test. Setting Materials/*/outputs=csv is still needed if a Postprocessor depends on the aux variables that are created when material properties are outputted to a CSV output object

Therefore, this change should fix the public app test failures that are happening in https://github.com/idaholab/moose/pull/29820, and it should not require any re-golding of malamute tests