### PR TITLE
Remove HTML-style comment syntax in favor of that of MooseDocs

### DIFF
--- a/doc/content/demonstration/index.md
+++ b/doc/content/demonstration/index.md
@@ -17,7 +17,7 @@ are described in this section.
 
 1. [verification/thermal_contact_verification.md]
 
-<!--TODO: These comments should be removed when example problems for MALAMUTE exist-->
+!! TODO: These comments should be removed when example problems for MALAMUTE exist
 !! ## Example Problems
 
 !! Examples of MALAMUTE usage are described in this section.


### PR DESCRIPTION
## Reason
HTML-style comment syntax is being removed in idaholab/moose#29581. All applications that use this syntax should be converted to MooseDocs-style syntax (`!!` for single-line, pair of `!!!` for multi-line). 

## Design
Update all markdown comment syntax.

## Impact
No impact to documentation or user experience.
