### PR TITLE
Remove output_properties parameter wherever it is unused

### DIFF
--- a/examples/sps/multiapp/diemodel/electrothermal/electrothermal_plunger_powder.i
+++ b/examples/sps/multiapp/diemodel/electrothermal/electrothermal_plunger_powder.i
@@ -397,7 +397,6 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = 'thermal_conductivity heat_capacity'
     block = 'upper_plunger lower_plunger die_wall'
   []
   # [graphite_electrical]

--- a/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_bothends_pressurebc.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_bothends_pressurebc.i
@@ -533,7 +533,6 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = 'thermal_conductivity heat_capacity'
     block = 'upper_plunger lower_plunger die_wall'
   []
   # [graphite_electrical]

--- a/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_creep.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/electrothermomechanical_plunger_powder_creep.i
@@ -534,7 +534,6 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = 'thermal_conductivity heat_capacity'
     block = 'upper_plunger lower_plunger die_wall'
   []
   # [graphite_electrical]

--- a/examples/sps/multiapp/diemodel/electrothermomechs/simple_geometries/graphite_electrothermalmech_singleblock.i
+++ b/examples/sps/multiapp/diemodel/electrothermomechs/simple_geometries/graphite_electrothermalmech_singleblock.i
@@ -348,7 +348,6 @@ initial_temperature = 300 #roughly 600C where the pyrometer kicks in
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = 'thermal_conductivity heat_capacity'
     block = 'upper_plunger'
   []
   [graphite_electrical_conductivity]

--- a/test/tests/materials/graphite/thermal/ad_graphite_thermal_material_properties.i
+++ b/test/tests/materials/graphite/thermal/ad_graphite_thermal_material_properties.i
@@ -59,7 +59,6 @@
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = all
   []
   [graphite_density]
     type = ADGenericConstantMaterial

--- a/test/tests/materials/graphite/thermal/graphite_thermal_material_properties.i
+++ b/test/tests/materials/graphite/thermal/graphite_thermal_material_properties.i
@@ -59,7 +59,6 @@
   [graphite_thermal]
     type = ADGraphiteThermal
     temperature = temperature
-    output_properties = all
   []
   [graphite_density]
     type = ADGenericConstantMaterial

--- a/test/tests/materials/stainless_steel/thermal/ad_stainless_steel_thermal_material_properties.i
+++ b/test/tests/materials/stainless_steel/thermal/ad_stainless_steel_thermal_material_properties.i
@@ -58,7 +58,6 @@
   [stainless_steel_thermal]
     type = ADStainlessSteelThermal
     temperature = temperature
-    output_properties = all
   []
   [stainless_steel_density]
     type = ADGenericConstantMaterial

--- a/test/tests/materials/stainless_steel/thermal/stainless_steel_thermal_material_properties.i
+++ b/test/tests/materials/stainless_steel/thermal/stainless_steel_thermal_material_properties.i
@@ -59,7 +59,6 @@
   [stainless_steel_thermal]
     type = StainlessSteelThermal
     temperature = temperature
-    output_properties = all
   []
   [stainless_steel_density]
     type = GenericConstantMaterial


### PR DESCRIPTION
One more follow-up PR related to https://github.com/idaholab/moose/pull/29820

A warning was added that triggers when `output_properties` is defined without a corresponding `outputs` parameter in the materials output system. This PR removes these instances in Malamute, since this causes public tests to fail otherwise