### PR TITLE
Update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ at https://mooseframework.inl.gov/malamute.
 MALAMUTE is based on the MOOSE framework, with more information on MOOSE
 to be found at https://mooseframework.inl.gov.
 
-Copyright 2021 - 2024, Battelle Energy Alliance, LLC
+Copyright 2021 - 2025, Battelle Energy Alliance, LLC

--- a/include/base/MalamuteApp.h
+++ b/include/base/MalamuteApp.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/base/MalamuteHeader.h
+++ b/include/base/MalamuteHeader.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/bcs/ADCoupledSimpleRadiativeHeatFluxBC.h
+++ b/include/bcs/ADCoupledSimpleRadiativeHeatFluxBC.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/indicators/AbsoluteValueIndicator.h
+++ b/include/indicators/AbsoluteValueIndicator.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/interfacekernels/ThermalContactCondition.h
+++ b/include/interfacekernels/ThermalContactCondition.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/INSMeltPoolMomentumSource.h
+++ b/include/kernels/INSMeltPoolMomentumSource.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/LevelSetCurvatureRegularization.h
+++ b/include/kernels/LevelSetCurvatureRegularization.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/LevelSetGradientRegularizationReinitialization.h
+++ b/include/kernels/LevelSetGradientRegularizationReinitialization.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/LevelSetPhaseChange.h
+++ b/include/kernels/LevelSetPhaseChange.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/LevelSetPhaseChangeSUPG.h
+++ b/include/kernels/LevelSetPhaseChangeSUPG.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/LevelSetPowderAddition.h
+++ b/include/kernels/LevelSetPowderAddition.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/MeltPoolHeatSource.h
+++ b/include/kernels/MeltPoolHeatSource.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/kernels/VariableGradientRegularization.h
+++ b/include/kernels/VariableGradientRegularization.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/ADFunctionPathGaussianHeatSource.h
+++ b/include/materials/ADFunctionPathGaussianHeatSource.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/ADGaussianHeatSourceBase.h
+++ b/include/materials/ADGaussianHeatSourceBase.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/ADVelocityGaussianHeatSource.h
+++ b/include/materials/ADVelocityGaussianHeatSource.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/GraphiteElectricalConductivity.h
+++ b/include/materials/GraphiteElectricalConductivity.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/GraphiteStainlessMeanHardness.h
+++ b/include/materials/GraphiteStainlessMeanHardness.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/GraphiteThermal.h
+++ b/include/materials/GraphiteThermal.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/GraphiteThermalExpansionEigenstrain.h
+++ b/include/materials/GraphiteThermalExpansionEigenstrain.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/INSMeltPoolMassTransferMaterial.h
+++ b/include/materials/INSMeltPoolMassTransferMaterial.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/INSMeltPoolMaterial.h
+++ b/include/materials/INSMeltPoolMaterial.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/LevelSetDeltaFunction.h
+++ b/include/materials/LevelSetDeltaFunction.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/LevelSetFluidMaterial.h
+++ b/include/materials/LevelSetFluidMaterial.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/LevelSetHeavisideFunction.h
+++ b/include/materials/LevelSetHeavisideFunction.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/LevelSetThermalMaterial.h
+++ b/include/materials/LevelSetThermalMaterial.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/MushyZoneMaterial.h
+++ b/include/materials/MushyZoneMaterial.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/RosenthalTemperatureSource.h
+++ b/include/materials/RosenthalTemperatureSource.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/StainlessSteelElectricalConductivity.h
+++ b/include/materials/StainlessSteelElectricalConductivity.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/StainlessSteelThermal.h
+++ b/include/materials/StainlessSteelThermal.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/include/materials/StainlessSteelThermalExpansionEigenstrain.h
+++ b/include/materials/StainlessSteelThermalExpansionEigenstrain.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/scripts/drsinter_data_extraction.py
+++ b/scripts/drsinter_data_extraction.py
@@ -5,7 +5,7 @@
 # /*                                                                          */
 # /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 # /*                                                                          */
-# /*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+# /*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 # /*                           ALL RIGHTS RESERVED                            */
 # /****************************************************************************/
 

--- a/src/base/MalamuteApp.C
+++ b/src/base/MalamuteApp.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/base/MalamuteHeader.C
+++ b/src/base/MalamuteHeader.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 
@@ -25,7 +25,7 @@ header()
          << "\n\n"
          << "MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs \n"
          << "\n\n"
-         << "Copyright 2021 - 2024, Battelle Energy Alliance, LLC \n"
+         << "Copyright 2021 - 2025, Battelle Energy Alliance, LLC \n"
          << "ALL RIGHTS RESERVED \n"
          << "\n\n"
          << "NOTICE: These data were produced by BATTELLE ENERGY ALLIANCE, LLC under Contract \n"

--- a/src/bcs/ADCoupledSimpleRadiativeHeatFluxBC.C
+++ b/src/bcs/ADCoupledSimpleRadiativeHeatFluxBC.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/indicators/AbsoluteValueIndicator.C
+++ b/src/indicators/AbsoluteValueIndicator.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/interfacekernels/ThermalContactCondition.C
+++ b/src/interfacekernels/ThermalContactCondition.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/INSMeltPoolMomentumSource.C
+++ b/src/kernels/INSMeltPoolMomentumSource.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/LevelSetCurvatureRegularization.C
+++ b/src/kernels/LevelSetCurvatureRegularization.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/LevelSetGradientRegularizationReinitialization.C
+++ b/src/kernels/LevelSetGradientRegularizationReinitialization.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/LevelSetPhaseChange.C
+++ b/src/kernels/LevelSetPhaseChange.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/LevelSetPhaseChangeSUPG.C
+++ b/src/kernels/LevelSetPhaseChangeSUPG.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/LevelSetPowderAddition.C
+++ b/src/kernels/LevelSetPowderAddition.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/MeltPoolHeatSource.C
+++ b/src/kernels/MeltPoolHeatSource.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/kernels/VariableGradientRegularization.C
+++ b/src/kernels/VariableGradientRegularization.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/main.C
+++ b/src/main.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/ADFunctionPathGaussianHeatSource.C
+++ b/src/materials/ADFunctionPathGaussianHeatSource.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/ADGaussianHeatSourceBase.C
+++ b/src/materials/ADGaussianHeatSourceBase.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/ADVelocityGaussianHeatSource.C
+++ b/src/materials/ADVelocityGaussianHeatSource.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/GraphiteElectricalConductivity.C
+++ b/src/materials/GraphiteElectricalConductivity.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/GraphiteStainlessMeanHardness.C
+++ b/src/materials/GraphiteStainlessMeanHardness.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/GraphiteThermal.C
+++ b/src/materials/GraphiteThermal.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/GraphiteThermalExpansionEigenstrain.C
+++ b/src/materials/GraphiteThermalExpansionEigenstrain.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/INSMeltPoolMassTransferMaterial.C
+++ b/src/materials/INSMeltPoolMassTransferMaterial.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/INSMeltPoolMaterial.C
+++ b/src/materials/INSMeltPoolMaterial.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/LevelSetDeltaFunction.C
+++ b/src/materials/LevelSetDeltaFunction.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/LevelSetFluidMaterial.C
+++ b/src/materials/LevelSetFluidMaterial.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/LevelSetHeavisideFunction.C
+++ b/src/materials/LevelSetHeavisideFunction.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/LevelSetThermalMaterial.C
+++ b/src/materials/LevelSetThermalMaterial.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/MushyZoneMaterial.C
+++ b/src/materials/MushyZoneMaterial.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/RosenthalTemperatureSource.C
+++ b/src/materials/RosenthalTemperatureSource.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/StainlessSteelElectricalConductivity.C
+++ b/src/materials/StainlessSteelElectricalConductivity.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/StainlessSteelThermal.C
+++ b/src/materials/StainlessSteelThermal.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/src/materials/StainlessSteelThermalExpansionEigenstrain.C
+++ b/src/materials/StainlessSteelThermalExpansionEigenstrain.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/include/base/MalamuteTestApp.h
+++ b/test/include/base/MalamuteTestApp.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/include/functions/ThermalContactPotentialTestFunc.h
+++ b/test/include/functions/ThermalContactPotentialTestFunc.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/include/functions/ThermalContactTemperatureTestFunc.h
+++ b/test/include/functions/ThermalContactTemperatureTestFunc.h
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/src/base/MalamuteTestApp.C
+++ b/test/src/base/MalamuteTestApp.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/src/functions/ThermalContactPotentialTestFunc.C
+++ b/test/src/functions/ThermalContactPotentialTestFunc.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/test/src/functions/ThermalContactTemperatureTestFunc.C
+++ b/test/src/functions/ThermalContactTemperatureTestFunc.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 

--- a/unit/src/main.C
+++ b/unit/src/main.C
@@ -3,7 +3,7 @@
 /*                                                                          */
 /* MALAMUTE: MOOSE Application Library for Advanced Manufacturing UTilitiEs */
 /*                                                                          */
-/*           Copyright 2021 - 2024, Battelle Energy Alliance, LLC           */
+/*           Copyright 2021 - 2025, Battelle Energy Alliance, LLC           */
 /*                           ALL RIGHTS RESERVED                            */
 /****************************************************************************/
 


### PR DESCRIPTION
## Reason
The copyright year for MALAMUTE needs to be updated from 2024 to 2025.

## Design
Change all locations where `Copyright 2021 - 2024` is asserted to include 2025.

## Impact
Keeps copyright notice in compliance.