### PR TITLE
Update for MetaPhysicL 2.0

### DIFF
--- a/src/interfacekernels/ThermalContactCondition.C
+++ b/src/interfacekernels/ThermalContactCondition.C
@@ -101,6 +101,7 @@ ThermalContactCondition::computeQpResidual(Moose::DGResidualType type)
   else if (_mean_hardness_was_set && !_thermal_conductance_was_set &&
            !_electrical_conductance_was_set)
   {
+    using std::pow;
     ADReal mean_thermal_conductivity =
         2 * _thermal_conductivity_primary[_qp] * _thermal_conductivity_secondary[_qp] /
         (_thermal_conductivity_primary[_qp] + _thermal_conductivity_secondary[_qp]);
@@ -111,13 +112,11 @@ ThermalContactCondition::computeQpResidual(Moose::DGResidualType type)
 
     thermal_contact_conductance =
         _alpha_thermal * mean_thermal_conductivity *
-        std::pow((_mechanical_pressure.value(_t, _q_point[_qp]) / _mean_hardness[_qp]),
-                 _beta_thermal);
+        pow((_mechanical_pressure.value(_t, _q_point[_qp]) / _mean_hardness[_qp]), _beta_thermal);
 
     electrical_contact_conductance =
         _alpha_electric * mean_electrical_conductivity *
-        std::pow((_mechanical_pressure.value(_t, _q_point[_qp]) / _mean_hardness[_qp]),
-                 _beta_electric);
+        pow((_mechanical_pressure.value(_t, _q_point[_qp]) / _mean_hardness[_qp]), _beta_electric);
   }
   else
   {

--- a/src/kernels/LevelSetPowderAddition.C
+++ b/src/kernels/LevelSetPowderAddition.C
@@ -48,6 +48,7 @@ LevelSetPowderAddition::LevelSetPowderAddition(const InputParameters & parameter
 ADReal
 LevelSetPowderAddition::precomputeQpResidual()
 {
+  using std::exp;
   Point p(0, 0, 0);
   RealVectorValue laser_location(_laser_location_x.value(_t, p),
                                  _laser_location_y.value(_t, p),
@@ -59,7 +60,7 @@ LevelSetPowderAddition::precomputeQpResidual()
 
   if (r <= _mass_radius)
     power_feed = _mass_scale * _eta_p * _mass_rate *
-                 std::exp(-_mass_scale * Utility::pow<2>(r / _mass_radius)) / _rho_p / libMesh::pi /
+                 exp(-_mass_scale * Utility::pow<2>(r / _mass_radius)) / _rho_p / libMesh::pi /
                  Utility::pow<2>(_mass_radius);
 
   return _delta_function[_qp] * power_feed;

--- a/src/kernels/MeltPoolHeatSource.C
+++ b/src/kernels/MeltPoolHeatSource.C
@@ -62,6 +62,7 @@ MeltPoolHeatSource::MeltPoolHeatSource(const InputParameters & parameters)
 ADReal
 MeltPoolHeatSource::precomputeQpResidual()
 {
+  using std::exp;
   Point p(0, 0, 0);
   RealVectorValue laser_location(_laser_location_x.value(_t, p),
                                  _laser_location_y.value(_t, p),
@@ -70,7 +71,7 @@ MeltPoolHeatSource::precomputeQpResidual()
   ADReal r = (_ad_q_point[_qp] - laser_location).norm();
 
   ADReal laser_source = 2 * _power.value(_t, p) * _alpha / (libMesh::pi * Utility::pow<2>(_Rb)) *
-                        std::exp(-2.0 * Utility::pow<2>(r / _Rb));
+                        exp(-2.0 * Utility::pow<2>(r / _Rb));
 
   ADReal convection = -_Ah * (_u[_qp] - _T0);
   ADReal radiation =

--- a/src/materials/GraphiteThermalExpansionEigenstrain.C
+++ b/src/materials/GraphiteThermalExpansionEigenstrain.C
@@ -77,7 +77,8 @@ ValueAndDerivative<is_ad>
 GraphiteThermalExpansionEigenstrainTempl<is_ad>::computeCoefficientThermalExpansion(
     const ValueAndDerivative<is_ad> & temperature)
 {
+  using std::log;
   const auto coefficient_thermal_expansion =
-      1.996e-6 * std::log(4.799e-2 * temperature) - 4.041e-6; // in 1/K
+      1.996e-6 * log(4.799e-2 * temperature) - 4.041e-6; // in 1/K
   return coefficient_thermal_expansion * _coeff_thermal_expansion_scale_factor;
 }

--- a/src/materials/INSMeltPoolMassTransferMaterial.C
+++ b/src/materials/INSMeltPoolMassTransferMaterial.C
@@ -43,11 +43,11 @@ INSMeltPoolMassTransferMaterial::INSMeltPoolMassTransferMaterial(const InputPara
 void
 INSMeltPoolMassTransferMaterial::computeQpProperties()
 {
-  _saturated_vapor_pressure[_qp] =
-      _p0 * std::exp(_m * _Lv / _boltzmann / _vaporization_temperature *
-                     (1 - _vaporization_temperature / _temp[_qp]));
+  using std::exp;
+  using std::sqrt;
+  _saturated_vapor_pressure[_qp] = _p0 * exp(_m * _Lv / _boltzmann / _vaporization_temperature *
+                                             (1 - _vaporization_temperature / _temp[_qp]));
 
-  _melt_pool_mass_rate[_qp] = std::sqrt(_m / (2 * libMesh::pi * _boltzmann)) *
-                              _saturated_vapor_pressure[_qp] / std::sqrt(_temp[_qp]) *
-                              (1 - _beta_r);
+  _melt_pool_mass_rate[_qp] = sqrt(_m / (2 * libMesh::pi * _boltzmann)) *
+                              _saturated_vapor_pressure[_qp] / sqrt(_temp[_qp]) * (1 - _beta_r);
 }

--- a/src/materials/RosenthalTemperatureSource.C
+++ b/src/materials/RosenthalTemperatureSource.C
@@ -57,25 +57,27 @@ template <bool is_ad>
 void
 RosenthalTemperatureSourceTempl<is_ad>::computeQpProperties()
 {
+  using std::exp;
+  using std::sqrt;
   const Real & x = _q_point[_qp](0);
   const Real & y = _q_point[_qp](1);
   const Real & z = _q_point[_qp](2);
 
   // Moving heat source and distance
   Real x_t = x - _x0 - _V * _t;
-  Real r = std::sqrt(x_t * x_t + y * y + z * z);
+  Real r = sqrt(x_t * x_t + y * y + z * z);
 
   _thermal_diffusivity[_qp] = _thermal_conductivity[_qp] / (_specific_heat[_qp] * _density[_qp]);
 
   _temp_source[_qp] = _T0 + (_absorptivity[_qp] * _P) /
                                 (2.0 * libMesh::pi * _thermal_conductivity[_qp] * r) *
-                                std::exp(-_V / (2.0 * _thermal_diffusivity[_qp]) * (r + x_t));
+                                exp(-_V / (2.0 * _thermal_diffusivity[_qp]) * (r + x_t));
   if (_temp_source[_qp] > _Tm)
     _temp_source[_qp] = _Tm;
 
   _meltpool_depth[_qp] =
-      std::sqrt((2.0 * _absorptivity[_qp] * _P) / (std::exp(1.0) * libMesh::pi * _density[_qp] *
-                                                   _specific_heat[_qp] * (_Tm - _T0) * _V));
+      sqrt((2.0 * _absorptivity[_qp] * _P) /
+           (exp(1.0) * libMesh::pi * _density[_qp] * _specific_heat[_qp] * (_Tm - _T0) * _V));
 
   _meltpool_width[_qp] = 2.0 * _meltpool_depth[_qp];
 }


### PR DESCRIPTION
Refs incoming MetaPhysicL 2.0 changes in
[idaholab/moose#31906](https://github.com/idaholab/moose/pull/31906). MetaPhysicL used to put its overloads in the std namespace which is not standard compliant. However, this is fixed in MetaPhysicL 2.0. This patch will allow both backward and forward compatibility with MetaPhysicL 1 and 2 respectively